### PR TITLE
feat: implement Checkbox component #34

### DIFF
--- a/src/components/Checkbox/Checkbox.css
+++ b/src/components/Checkbox/Checkbox.css
@@ -1,36 +1,175 @@
+/* ── Base ── */
 .vega-checkbox {
-    display: flex;
-    align-items: center;
-    color: #000000;
+  --vega-checkbox-size: 1.25rem;
+  --vega-checkbox-radius: 0.25rem;
+  --vega-checkbox-gap: 0.5rem;
+  --vega-checkbox-border: var(--border-default, #d1d5db);
+  --vega-checkbox-bg: var(--bg-surface, #ffffff);
+  --vega-checkbox-checked-bg: var(--color-primary, #6d28d9);
+  --vega-checkbox-checked-border: var(--color-primary, #6d28d9);
+  --vega-checkbox-icon-color: var(--text-inverse, #ffffff);
+  --vega-checkbox-focus: var(--border-focus, #111827);
+  --vega-checkbox-transition: border-color 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
+
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-family: system-ui, -apple-system, sans-serif;
+  color: var(--text-main, #111827);
 }
 
+.vega-checkbox--full-width {
+  display: flex;
+  width: 100%;
+}
+
+/* ── Sizes ── */
+.vega-checkbox--small {
+  --vega-checkbox-size: 1rem;
+  --vega-checkbox-gap: 0.375rem;
+  font-size: 0.875rem;
+}
+
+.vega-checkbox--medium {
+  --vega-checkbox-size: 1.25rem;
+  --vega-checkbox-gap: 0.5rem;
+  font-size: 1rem;
+}
+
+.vega-checkbox--large {
+  --vega-checkbox-size: 1.5rem;
+  --vega-checkbox-gap: 0.625rem;
+  font-size: 1.125rem;
+}
+
+/* ── Control row (label + box) ── */
+.vega-checkbox__control {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--vega-checkbox-gap);
+  cursor: pointer;
+  user-select: none;
+}
+
+.vega-checkbox--disabled .vega-checkbox__control {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* ── Hidden native input (sr-only) ── */
 .vega-checkbox__input {
-    display: flex;
-    align-items: end;
-    opacity: 1;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
+/* ── Custom box ── */
+.vega-checkbox__box {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--vega-checkbox-size);
+  height: var(--vega-checkbox-size);
+  border: 1.5px solid var(--vega-checkbox-border);
+  border-radius: var(--vega-checkbox-radius);
+  background-color: var(--vega-checkbox-bg);
+  color: var(--vega-checkbox-icon-color);
+  transition: var(--vega-checkbox-transition);
+  flex-shrink: 0;
+}
+
+/* ── Icons ── */
+.vega-checkbox__icon {
+  display: none;
+  width: 65%;
+  height: 65%;
+  stroke-width: 3;
+}
+
+/* ── Hover ── */
+.vega-checkbox__input:hover:not(:disabled) + .vega-checkbox__box {
+  border-color: var(--color-primary, #6d28d9);
+}
+
+/* ── Focus ── */
+.vega-checkbox__input:focus-visible + .vega-checkbox__box {
+  outline: 2px solid var(--vega-checkbox-focus);
+  outline-offset: 2px;
+}
+
+/* ── Checked ── */
+.vega-checkbox__input:checked + .vega-checkbox__box {
+  background-color: var(--vega-checkbox-checked-bg);
+  border-color: var(--vega-checkbox-checked-border);
+}
+
+.vega-checkbox__input:checked + .vega-checkbox__box .vega-checkbox__icon--check {
+  display: block;
+}
+
+/* ── Indeterminate ── */
+.vega-checkbox__input:indeterminate + .vega-checkbox__box {
+  background-color: var(--vega-checkbox-checked-bg);
+  border-color: var(--vega-checkbox-checked-border);
+}
+
+.vega-checkbox__input:indeterminate + .vega-checkbox__box .vega-checkbox__icon--indeterminate {
+  display: block;
+}
+
+.vega-checkbox__input:indeterminate + .vega-checkbox__box .vega-checkbox__icon--check {
+  display: none;
+}
+
+/* ── Disabled ── */
+.vega-checkbox__input:disabled + .vega-checkbox__box {
+  background-color: var(--bg-disabled, #f3f4f6);
+  border-color: var(--border-default, #d1d5db);
+}
+
+.vega-checkbox__input:disabled:checked + .vega-checkbox__box,
+.vega-checkbox__input:disabled:indeterminate + .vega-checkbox__box {
+  background-color: var(--color-primary, #6d28d9);
+  border-color: var(--color-primary, #6d28d9);
+  opacity: 0.5;
+}
+
+/* ── Error ── */
+.vega-checkbox--error .vega-checkbox__box {
+  border-color: var(--color-error, #ef4444);
+}
+
+.vega-checkbox--error .vega-checkbox__input:checked + .vega-checkbox__box,
+.vega-checkbox--error .vega-checkbox__input:indeterminate + .vega-checkbox__box {
+  background-color: var(--color-error, #ef4444);
+  border-color: var(--color-error, #ef4444);
+}
+
+/* ── Label ── */
 .vega-checkbox__label {
-    margin-left: 8px;
+  line-height: 1.4;
 }
 
-.vega-checkbox__label--small + .vega-checkbox__input {
-    font-size: 15px;
-    align-items: center;
+/* ── Description ── */
+.vega-checkbox__description {
+  margin: 0;
+  padding-left: calc(var(--vega-checkbox-size) + var(--vega-checkbox-gap));
+  font-size: 0.75rem;
+  color: var(--text-secondary, #9ca3af);
+  line-height: 1.4;
 }
 
-.vega-checkbox__label--medium {
-    font-size: 20px;
-}
-
-.vega-checkbox__label--large {
-    font-size: 25px;
-}
-
-.vega-checkbox__input:checked + .vega-checkbox__label {
-    color: #007bff;
-}
-
-.vega-checkbox__input:disabled + .vega-checkbox__label {
-    color: #6c757d;
+/* ── Error message ── */
+.vega-checkbox__error {
+  margin: 0;
+  padding-left: calc(var(--vega-checkbox-size) + var(--vega-checkbox-gap));
+  font-size: 0.75rem;
+  color: var(--color-error, #ef4444);
+  line-height: 1.4;
 }

--- a/src/components/Checkbox/Checkbox.stories.tsx
+++ b/src/components/Checkbox/Checkbox.stories.tsx
@@ -1,30 +1,70 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+import { useState } from "react";
 import { Checkbox } from "./Checkbox";
+import type { CheckboxProps } from "./Checkbox.types";
 
-const meta: Meta<typeof Checkbox> = {
+const meta = {
   title: "Components/Checkbox",
   component: Checkbox,
-  tags: ["autodocs"],
-  args: {
-    onChange: () => {},
+  parameters: {
+    layout: "centered",
   },
-};
+  tags: ["autodocs"],
+  argTypes: {
+    size: {
+      control: "select",
+      options: ["small", "medium", "large"],
+      description: "Taille de la checkbox",
+    },
+    label: {
+      control: "text",
+      description: "Label affiché à côté de la checkbox",
+    },
+    description: {
+      control: "text",
+      description: "Texte descriptif sous la checkbox",
+    },
+    error: {
+      control: "text",
+      description: "Message d'erreur affiché sous la checkbox",
+    },
+    indeterminate: {
+      control: "boolean",
+      description: "État indéterminé (sélection partielle)",
+    },
+    disabled: {
+      control: "boolean",
+      description: "Désactiver la checkbox",
+    },
+    fullWidth: {
+      control: "boolean",
+      description: "Étendre à la largeur du conteneur",
+    },
+  },
+  args: { onChange: fn() },
+} satisfies Meta<typeof Checkbox>;
 
 export default meta;
-
-type Story = StoryObj<typeof Checkbox>;
+type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
     label: "Accepter les conditions",
-    checked: false,
   },
 };
 
 export const Checked: Story = {
   args: {
     label: "Option activée",
-    checked: true,
+    defaultChecked: true,
+  },
+};
+
+export const Indeterminate: Story = {
+  args: {
+    label: "Sélection partielle",
+    indeterminate: true,
   },
 };
 
@@ -35,10 +75,11 @@ export const Disabled: Story = {
   },
 };
 
-export const Indeterminate: Story = {
+export const DisabledChecked: Story = {
   args: {
-    label: "Sélection partielle",
-    indeterminate: true,
+    label: "Option validée (non modifiable)",
+    disabled: true,
+    defaultChecked: true,
   },
 };
 
@@ -64,4 +105,38 @@ export const Sizes: Story = {
       <Checkbox {...args} size="large" label="Grande (Large)" />
     </div>
   ),
+};
+
+export const AllStates: Story = {
+  render: (args) => (
+    <div style={{ display: "flex", flexDirection: "column", gap: "1.5rem" }}>
+      <Checkbox {...args} label="Default" />
+      <Checkbox {...args} label="Checked" defaultChecked />
+      <Checkbox {...args} label="Indeterminate" indeterminate />
+      <Checkbox {...args} label="Disabled" disabled />
+      <Checkbox {...args} label="Disabled Checked" disabled defaultChecked />
+      <Checkbox {...args} label="Error" error="Ce champ est requis." />
+      <Checkbox
+        {...args}
+        label="With description"
+        description="Texte descriptif complémentaire."
+      />
+    </div>
+  ),
+};
+
+const InteractiveCheckbox = (args: CheckboxProps) => {
+  const [checked, setChecked] = useState(false);
+  return (
+    <Checkbox
+      {...args}
+      label={checked ? "Activé" : "Désactivé"}
+      checked={checked}
+      onChange={() => setChecked(!checked)}
+    />
+  );
+};
+
+export const Interactive: Story = {
+  render: (args) => <InteractiveCheckbox {...args} />,
 };

--- a/src/components/Checkbox/Checkbox.test.tsx
+++ b/src/components/Checkbox/Checkbox.test.tsx
@@ -1,40 +1,74 @@
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import { describe, it, expect, vi } from 'vitest';
-import { Checkbox } from './Checkbox';
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import { Checkbox } from "./Checkbox";
 
-describe('Checkbox', () => {
-  it('renders with label', () => {
+describe("Checkbox", () => {
+  it("renders a checkbox input", () => {
+    render(<Checkbox />);
+    expect(screen.getByRole("checkbox")).toBeInTheDocument();
+  });
+
+  it("renders with label", () => {
     render(<Checkbox label="Accept terms" />);
-    expect(screen.getByText('Accept terms')).toBeInTheDocument();
+    expect(screen.getByLabelText("Accept terms")).toBeInTheDocument();
   });
 
-  it('renders with description', () => {
+  it("renders with description", () => {
     render(<Checkbox label="Newsletter" description="Weekly updates" />);
-    expect(screen.getByText('Weekly updates')).toBeInTheDocument();
+    expect(screen.getByText("Weekly updates")).toBeInTheDocument();
+    expect(screen.getByRole("checkbox")).toHaveAttribute("aria-describedby");
   });
 
-  it('applies size class to label', () => {
-    render(<Checkbox label="Test" size="large" />);
-    const label = screen.getByText('Test');
-    expect(label).toHaveClass('vega-checkbox__label--large');
-  });
-
-  it('calls onChange with checked state', async () => {
+  it("calls onChange on click", async () => {
     const user = userEvent.setup();
     const handleChange = vi.fn();
     render(<Checkbox label="Check" onChange={handleChange} />);
-    await user.click(screen.getByRole('checkbox'));
-    expect(handleChange).toHaveBeenCalledWith(true);
+    await user.click(screen.getByRole("checkbox"));
+    expect(handleChange).toHaveBeenCalledOnce();
   });
 
-  it('renders a checkbox input', () => {
-    render(<Checkbox label="Test" />);
-    expect(screen.getByRole('checkbox')).toBeInTheDocument();
+  it("supports controlled checked state", () => {
+    render(<Checkbox label="Controlled" checked onChange={() => {}} />);
+    expect(screen.getByRole("checkbox")).toBeChecked();
   });
 
-  it('uses default size (small)', () => {
-    render(<Checkbox label="Default" />);
-    expect(screen.getByText('Default')).toHaveClass('vega-checkbox__label--small');
+  it("supports uncontrolled with defaultChecked", () => {
+    render(<Checkbox label="Uncontrolled" defaultChecked />);
+    expect(screen.getByRole("checkbox")).toBeChecked();
+  });
+
+  it("can be disabled", () => {
+    const handleChange = vi.fn();
+    render(<Checkbox label="Disabled" disabled onChange={handleChange} />);
+    expect(screen.getByRole("checkbox")).toBeDisabled();
+  });
+
+  it("handles indeterminate state", () => {
+    render(<Checkbox label="Indeterminate" indeterminate />);
+    const checkbox = screen.getByRole("checkbox");
+    expect((checkbox as HTMLInputElement).indeterminate).toBe(true);
+    expect(checkbox).toHaveAttribute("aria-checked", "mixed");
+  });
+
+  it("displays error state and message", () => {
+    render(<Checkbox label="Terms" error="Required field" />);
+    expect(screen.getByText("Required field")).toBeInTheDocument();
+    expect(screen.getByRole("checkbox")).toHaveAttribute("aria-invalid", "true");
+  });
+
+  it("applies size class", () => {
+    const { container } = render(<Checkbox label="Small" size="small" />);
+    expect(container.firstChild).toHaveClass("vega-checkbox--small");
+  });
+
+  it("applies fullWidth class", () => {
+    const { container } = render(<Checkbox label="Full" fullWidth />);
+    expect(container.firstChild).toHaveClass("vega-checkbox--full-width");
+  });
+
+  it("uses provided id", () => {
+    render(<Checkbox id="my-checkbox" label="Custom ID" />);
+    expect(screen.getByRole("checkbox")).toHaveAttribute("id", "my-checkbox");
   });
 });

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -1,31 +1,90 @@
+import React, { useId, useRef, useEffect } from "react";
+import { Check, Minus } from "lucide-react";
 import type { CheckboxProps } from "./Checkbox.types";
 import "./Checkbox.css";
 
 export const Checkbox: React.FC<CheckboxProps> = ({
   label,
   description,
-  size = "small",
+  size = "medium",
   indeterminate = false,
+  error,
+  fullWidth = false,
+  className = "",
+  id,
+  disabled = false,
+  checked,
+  defaultChecked,
   onChange,
+  ...props
 }) => {
-  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    onChange?.(event.target.checked);
-  };
+  const generatedId = useId();
+  const inputId = id || generatedId;
+  const errorId = `${inputId}-error`;
+  const descriptionId = `${inputId}-description`;
+
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.indeterminate = indeterminate;
+    }
+  }, [indeterminate]);
+
+  const isControlled = checked !== undefined;
+
+  const describedBy = [
+    description ? descriptionId : "",
+    error ? errorId : "",
+  ]
+    .filter(Boolean)
+    .join(" ") || undefined;
+
+  const wrapperClasses = [
+    "vega-checkbox",
+    `vega-checkbox--${size}`,
+    error ? "vega-checkbox--error" : "",
+    disabled ? "vega-checkbox--disabled" : "",
+    fullWidth ? "vega-checkbox--full-width" : "",
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
 
   return (
-    <div className="vega-checkbox">
-      <input
-        className="vega-checkbox__input"
-        type="checkbox"
-        checked={indeterminate ? false : undefined}
-        onChange={handleChange}
-      />
-      <label className={`vega-checkbox__label vega-checkbox__label--${size}`}>
-        {label}
-        {description && (
-          <span className="vega-checkbox__description">{description}</span>
-        )}
+    <div className={wrapperClasses}>
+      <label className="vega-checkbox__control" htmlFor={inputId}>
+        <input
+          ref={inputRef}
+          id={inputId}
+          type="checkbox"
+          className="vega-checkbox__input"
+          disabled={disabled}
+          aria-invalid={error ? true : undefined}
+          aria-describedby={describedBy}
+          aria-checked={indeterminate ? "mixed" : undefined}
+          {...(isControlled ? { checked } : { defaultChecked })}
+          onChange={onChange}
+          {...props}
+        />
+        <span className="vega-checkbox__box" aria-hidden="true">
+          <Check className="vega-checkbox__icon vega-checkbox__icon--check" />
+          <Minus className="vega-checkbox__icon vega-checkbox__icon--indeterminate" />
+        </span>
+        {label && <span className="vega-checkbox__label">{label}</span>}
       </label>
+
+      {description && (
+        <p id={descriptionId} className="vega-checkbox__description">
+          {description}
+        </p>
+      )}
+
+      {error && (
+        <p id={errorId} className="vega-checkbox__error">
+          {error}
+        </p>
+      )}
     </div>
   );
 };

--- a/src/components/Checkbox/Checkbox.types.ts
+++ b/src/components/Checkbox/Checkbox.types.ts
@@ -1,10 +1,11 @@
 import type { InputHTMLAttributes, ReactNode } from "react";
 
 export interface CheckboxProps
-  extends Omit<InputHTMLAttributes<HTMLInputElement>, "size"> {
+  extends Omit<InputHTMLAttributes<HTMLInputElement>, "size" | "type"> {
   label?: ReactNode;
   description?: ReactNode;
   size?: "small" | "medium" | "large";
   indeterminate?: boolean;
   error?: string;
+  fullWidth?: boolean;
 }


### PR DESCRIPTION
## Description

Rewrite complet du composant `Checkbox` pour corriger les lacunes de l'implémentation initiale.

- Gestion de l'état `indeterminate` via `useRef`/`useEffect`
- Custom visual checkbox (input sr-only + styled box) avec icônes Lucide (`Check`, `Minus`)
- Attributs ARIA complets : `aria-checked="mixed"`, `aria-invalid`, `aria-describedby`
- Support controlled/uncontrolled (`checked` / `defaultChecked`)
- 3 tailles (`small`, `medium`, `large`), états `disabled`, `error`, `fullWidth`
- Design tokens CSS avec variables custom au niveau composant
- 12 tests unitaires (vitest + testing-library)
- 10 stories Storybook (Default, Checked, Indeterminate, Disabled, DisabledChecked, WithDescription, WithError, Sizes, AllStates, Interactive)
- Setup vitest ajouté au projet (devDeps + config + setup file)

## Testing

- [ ] `Default` — checkbox non cochée avec label
- [ ] `Checked` — état coché par défaut
- [ ] `Indeterminate` — état indéterminé (dash icon)
- [ ] `Disabled` — checkbox désactivée (opacity + cursor)
- [ ] `DisabledChecked` — désactivée + cochée
- [ ] `WithDescription` — texte descriptif sous la checkbox
- [ ] `WithError` — message d'erreur + bordure rouge
- [ ] `Sizes` — small / medium / large côte à côte
- [ ] `AllStates` — vue d'ensemble de tous les états
- [ ] `Interactive` — toggle controlled avec useState
- [ ] Keyboard : Space toggle la checkbox, focus-visible visible

https://www.loom.com/share/c0407902123f4e4aa828717a3fdd8234?focus_title=1&muted=1&from_recorder=1

Closes #34