### PR TITLE
docs: add components list to README #72

### DIFF
--- a/COMPONENTS.md
+++ b/COMPONENTS.md
@@ -1,0 +1,33 @@
+# Components
+
+List of components available in the library.
+
+## Installation
+
+```bash
+npm install vega-react-components
+```
+
+
+## Forms
+
+- **Button** — Clickable action element with multiple variants and states.
+- **Checkbox** — Selectable input for boolean or multi-choice values.
+- **InputText** — Basic text input with label and validation support.
+- **InputEmail** — Text input with built-in email format validation.
+- **PhoneNumberInput** — Phone input with country code selection and formatting.
+
+## Feedback
+
+- **Loader** — Loading indicator (spinner, skeleton, progress bar) for async states.
+- **Toast** — Auto-dismissing notification system for transient messages.
+
+## Layout
+
+- **Card** — Container with variants and composition for grouping content.
+
+## Overlay
+
+- **Dialog** — Modal window with focus trap and accessibility built-in.
+- **Tooltip** — Contextual hint displayed on hover or focus.
+- **ContextMenu** — Right-click menu with custom actions.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This a library components made for my own usage, I will keep it public for every
 ## Installation
 
 ```bash
-npm install 
+npm install
 ```
 
 ---
@@ -16,3 +16,9 @@ npm install
 ```bash
 npm run storybook
 ```
+
+---
+
+## Components
+
+See [COMPONENTS.md](./COMPONENTS.md) for the full list of components.


### PR DESCRIPTION
## Description

Add a `COMPONENTS.md` file listing all components available on `main`, grouped by category (Forms / Feedback / Layout / Overlay) with a short description for each. The README links to it and stays focused on dev setup. The consumer install command (`npm install vega-react-components`) lives in `COMPONENTS.md`.

Closes #72

## Testing

- [ ] README and COMPONENTS.md render correctly on GitHub
- [ ] All 11 components on main are listed
- [ ] Links between README and COMPONENTS.md work