### PR TITLE
fix(ci): publish workflow auth + clean build type errors

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,9 +19,6 @@ jobs:
         with:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'
-      - run: npm install --legacy-peer-deps
-      - run: npm run build
-      - run: npm publish --access public
 
       - name: Install dependencies
         run: npm ci
@@ -30,6 +27,6 @@ jobs:
         run: npm run build
 
       - name: Publish to npm
-        run: npm publish --provenance
+        run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/src/components/Button/Button.types.ts
+++ b/src/components/Button/Button.types.ts
@@ -1,4 +1,4 @@
-import { ButtonHTMLAttributes, ReactNode } from 'react';
+import type { ButtonHTMLAttributes, ReactNode } from 'react';
 
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   /**

--- a/src/components/FormWrapper/FormWrapper.types.ts
+++ b/src/components/FormWrapper/FormWrapper.types.ts
@@ -1,4 +1,4 @@
-import { FormHTMLAttributes, ReactNode } from 'react';
+import type { FormHTMLAttributes, ReactNode } from 'react';
 
 export type FormWrapperGap = 'sm' | 'md' | 'lg';
 

--- a/src/components/InputEmail/InputEmail.types.ts
+++ b/src/components/InputEmail/InputEmail.types.ts
@@ -1,4 +1,4 @@
-import { InputHTMLAttributes, ReactNode } from 'react';
+import type { InputHTMLAttributes, ReactNode } from 'react';
 
 export interface InputEmailProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'type' | 'size'> {
   label?: ReactNode;

--- a/src/components/InputText/InputText.types.ts
+++ b/src/components/InputText/InputText.types.ts
@@ -1,4 +1,4 @@
-import { InputHTMLAttributes, ReactNode } from 'react';
+import type { InputHTMLAttributes, ReactNode } from 'react';
 
 export interface InputTextProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'size'> {
 

--- a/src/components/Navbar/Navbar.types.ts
+++ b/src/components/Navbar/Navbar.types.ts
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import type { ReactNode } from "react";
 
 export interface NavbarItemProps {
   label: string;

--- a/src/components/PhoneNumberInput/PhoneNumberInput.types.ts
+++ b/src/components/PhoneNumberInput/PhoneNumberInput.types.ts
@@ -1,5 +1,5 @@
-import { InputHTMLAttributes, ReactNode } from 'react';
-import { Country } from 'react-phone-number-input';
+import type { InputHTMLAttributes, ReactNode } from 'react';
+import type { Country } from 'react-phone-number-input';
 
 /**
  * Props for the PhoneNumberInput component.

--- a/src/components/Sidebar/Sidebar.types.ts
+++ b/src/components/Sidebar/Sidebar.types.ts
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import type { ReactNode } from "react";
 
 export interface SidebarItemProps {
   label: string;

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -24,5 +24,11 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": [
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.stories.ts",
+    "src/**/*.stories.tsx"
+  ]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,6 +11,12 @@ export default defineConfig({
       insertTypesEntry: true,
       tsconfigPath: resolve(__dirname, "tsconfig.app.json"),
       include: ["src/components/**/*", "src/index.ts"],
+      exclude: [
+        "src/**/*.test.ts",
+        "src/**/*.test.tsx",
+        "src/**/*.stories.ts",
+        "src/**/*.stories.tsx",
+      ],
     }),
   ],
   build: {


### PR DESCRIPTION
## Summary
- Corrige le workflow `publish.yml` : suppression du bloc dupliqué qui faisait un `npm publish` sans `NODE_AUTH_TOKEN` → cause du 404 lors du dernier publish.
- Exclut les fichiers `*.test.tsx` et `*.stories.tsx` du `tsconfig.app.json` et du plugin `vite-plugin-dts` (ils ne font pas partie de la lib publiée, et sont déjà vérifiés par Vitest / Storybook).
- Bascule les imports type-only des fichiers `*.types.ts` en `import type { ... }` pour satisfaire `verbatimModuleSyntax: true`.

## Why
Le build affichait une centaine d'erreurs TS (tests + stories + types) lors du `npm publish` en CI. Les erreurs n'empêchaient pas vite de produire un tarball, mais l'auth manquante sur le premier `npm publish` faisait échouer le job avec un 404.

## Test plan
- [x] `npm run build` local → plus aucune erreur TS, build clean
- [ ] Re-trigger `Publish to npm` workflow sur main après merge → publish doit aboutir avec le token
- [ ] Vérifier que les `.d.ts` générés dans `dist/components/` n'incluent plus les `*.test.d.ts` / `*.stories.d.ts`

## Out of scope
Warning rollup non bloquant : `"default" is imported from external module "react" but never used` dans 9 composants. Les fichiers utilisent `React.` pour des types (effacés à la compilation), laissant l'import orphelin au niveau JS. Pas touché ici pour limiter le diff.