### PR TITLE
feat: add ModelViewer 3D component for GLTF/GLB rendering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,11 @@
       "name": "vega-react-components",
       "version": "1.0.2",
       "license": "MIT",
+      "dependencies": {
+        "@react-three/drei": "^10.7.7",
+        "@react-three/fiber": "^9.6.1",
+        "three": "^0.184.0"
+      },
       "devDependencies": {
         "@eslint/js": "^9.36.0",
         "@storybook/addon-onboarding": "^10.2.12",
@@ -18,6 +23,7 @@
         "@types/node": "^24.10.2",
         "@types/react": "^19.1.16",
         "@types/react-dom": "^19.1.9",
+        "@types/three": "^0.184.1",
         "@vitejs/plugin-react": "^5.0.4",
         "eslint": "^9.36.0",
         "eslint-plugin-react-hooks": "^5.2.0",
@@ -277,7 +283,6 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -326,6 +331,12 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "license": "Apache-2.0"
     },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",
@@ -1047,6 +1058,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mediapipe/tasks-vision": {
+      "version": "0.10.17",
+      "resolved": "https://registry.npmjs.org/@mediapipe/tasks-vision/-/tasks-vision-0.10.17.tgz",
+      "integrity": "sha512-CZWV/q6TTe8ta61cZXjfnnHsfWIdFhms03M9T7Cnd5y2mdpylJM0rF1qRq+wsQVRMLz1OYPVEBU9ph2Bx8cxrg==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@microsoft/api-extractor": {
       "version": "7.43.0",
       "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.43.0.tgz",
@@ -1185,6 +1202,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@monogrid/gainmap-js": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@monogrid/gainmap-js/-/gainmap-js-3.4.0.tgz",
+      "integrity": "sha512-2Z0FATFHaoYJ8b+Y4y4Hgfn3FRFwuU5zRrk+9dFWp4uGAdHGqVEdP7HP+gLA3X469KXHmfupJaUbKo1b/aDKIg==",
+      "license": "MIT",
+      "dependencies": {
+        "promise-worker-transferable": "^1.0.4"
+      },
+      "peerDependencies": {
+        "three": ">= 0.159.0"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -1854,6 +1883,94 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@react-three/drei": {
+      "version": "10.7.7",
+      "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-10.7.7.tgz",
+      "integrity": "sha512-ff+J5iloR0k4tC++QtD/j9u3w5fzfgFAWDtAGQah9pF2B1YgOq/5JxqY0/aVoQG5r3xSZz0cv5tk2YuBob4xEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0",
+        "@mediapipe/tasks-vision": "0.10.17",
+        "@monogrid/gainmap-js": "^3.0.6",
+        "@use-gesture/react": "^10.3.1",
+        "camera-controls": "^3.1.0",
+        "cross-env": "^7.0.3",
+        "detect-gpu": "^5.0.56",
+        "glsl-noise": "^0.0.0",
+        "hls.js": "^1.5.17",
+        "maath": "^0.10.8",
+        "meshline": "^3.3.1",
+        "stats-gl": "^2.2.8",
+        "stats.js": "^0.17.0",
+        "suspend-react": "^0.1.3",
+        "three-mesh-bvh": "^0.8.3",
+        "three-stdlib": "^2.35.6",
+        "troika-three-text": "^0.52.4",
+        "tunnel-rat": "^0.1.2",
+        "use-sync-external-store": "^1.4.0",
+        "utility-types": "^3.11.0",
+        "zustand": "^5.0.1"
+      },
+      "peerDependencies": {
+        "@react-three/fiber": "^9.0.0",
+        "react": "^19",
+        "react-dom": "^19",
+        "three": ">=0.159"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-three/fiber": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.6.1.tgz",
+      "integrity": "sha512-zF0rsKcVYpcJwbFEnv2HkHX9cvOEgsfQo/X8lwmR2dn13S4qEQJXir9fxf5js2LQFoXqxOY7MDkOkYx2uZ4gSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.17.8",
+        "@types/webxr": "*",
+        "base64-js": "^1.5.1",
+        "buffer": "^6.0.3",
+        "its-fine": "^2.0.0",
+        "react-use-measure": "^2.1.7",
+        "scheduler": "^0.27.0",
+        "suspend-react": "^0.1.3",
+        "use-sync-external-store": "^1.4.0",
+        "zustand": "^5.0.3"
+      },
+      "peerDependencies": {
+        "expo": ">=43.0",
+        "expo-asset": ">=8.4",
+        "expo-file-system": ">=11.0",
+        "expo-gl": ">=11.0",
+        "react": ">=19 <19.3",
+        "react-dom": ">=19 <19.3",
+        "react-native": ">=0.78",
+        "three": ">=0.156"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        },
+        "expo-asset": {
+          "optional": true
+        },
+        "expo-file-system": {
+          "optional": true
+        },
+        "expo-gl": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",
@@ -2586,6 +2703,12 @@
         "@testing-library/dom": ">=7.21.4"
       }
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
@@ -2672,6 +2795,12 @@
       "integrity": "sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==",
       "dev": true
     },
+    "node_modules/@types/draco3d": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@types/draco3d/-/draco3d-1.4.10.tgz",
+      "integrity": "sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -2693,11 +2822,16 @@
         "undici-types": "~7.16.0"
       }
     },
+    "node_modules/@types/offscreencanvas": {
+      "version": "2019.7.3",
+      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
+      "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==",
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
       "version": "19.2.15",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
       "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
-      "dev": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2711,11 +2845,46 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/react-reconciler": {
+      "version": "0.28.9",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
+      "integrity": "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/resolve": {
       "version": "1.20.6",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.6.tgz",
       "integrity": "sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==",
       "dev": true
+    },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.184.1",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.184.1.tgz",
+      "integrity": "sha512-6q4VdiqVsrTRqmk62/BnlcAvIrnDM0zf2ZDVKI5kZiniWrSaOHaQzmbp+BNzoggc/8tgW412pL//wZIxu2PPTA==",
+      "license": "MIT",
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": ">=0.5.17",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~1.1.1"
+      }
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
+      "license": "MIT"
     },
     "node_modules/@types/whatwg-mimetype": {
       "version": "3.0.2",
@@ -3009,6 +3178,24 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@use-gesture/core": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.3.1.tgz",
+      "integrity": "sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==",
+      "license": "MIT"
+    },
+    "node_modules/@use-gesture/react": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.3.1.tgz",
+      "integrity": "sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@use-gesture/core": "10.3.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0"
       }
     },
     "node_modules/@vitejs/plugin-react": {
@@ -3443,6 +3630,26 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.31",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.31.tgz",
@@ -3453,6 +3660,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/brace-expansion": {
@@ -3510,6 +3726,30 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/bundle-name": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
@@ -3532,6 +3772,19 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/camera-controls": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/camera-controls/-/camera-controls-3.1.2.tgz",
+      "integrity": "sha512-xkxfpG2ECZ6Ww5/9+kf4mfg1VEYAoe9aDSY+IwF0UEs7qEzwy0aVRfs2grImIECs/PoBtWFrh7RXsQkwG922JA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.0.0",
+        "npm": ">=10.5.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.126.1"
       }
     },
     "node_modules/caniuse-lite": {
@@ -3653,11 +3906,28 @@
       "integrity": "sha512-Nmik0289ZVZSI3c7mJR/amg6DyY7Z59b0sTFSKayeX72mHfPzCPJygwJs2pYgQULzuAyWeCUgwAJ+Dq8OR+JFw==",
       "dev": true
     },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -3676,8 +3946,7 @@
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
-      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="
     },
     "node_modules/de-indent": {
       "version": "1.0.2",
@@ -3766,6 +4035,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/detect-gpu": {
+      "version": "5.0.70",
+      "resolved": "https://registry.npmjs.org/detect-gpu/-/detect-gpu-5.0.70.tgz",
+      "integrity": "sha512-bqerEP1Ese6nt3rFkwPnGbsUF9a4q+gMmpTVVOEzoCyeCc+y7/RvJnQZJx1JwhgQI5Ntg0Kgat8Uu7XpBqnz1w==",
+      "license": "MIT",
+      "dependencies": {
+        "webgl-constants": "^1.1.1"
+      }
+    },
     "node_modules/doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -3784,6 +4062,12 @@
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/draco3d": {
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/draco3d/-/draco3d-1.5.7.tgz",
+      "integrity": "sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.359",
@@ -4178,6 +4462,12 @@
         }
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -4375,6 +4665,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/glsl-noise": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/glsl-noise/-/glsl-noise-0.0.0.tgz",
+      "integrity": "sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w==",
+      "license": "MIT"
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -4428,6 +4724,32 @@
         "he": "bin/he"
       }
     },
+    "node_modules/hls.js": {
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.16.tgz",
+      "integrity": "sha512-VSIRpLfRwlAAdGL4wiTucx2ScRipo0ed1FBatWkyt832jC4CReKstga6yIhYVwGu9LOBjuX9wzmRMeQdBJtzEA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -4436,6 +4758,12 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
@@ -4579,6 +4907,12 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-promise": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+      "license": "MIT"
+    },
     "node_modules/is-wsl": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
@@ -4597,8 +4931,19 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
+    "node_modules/its-fine": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/its-fine/-/its-fine-2.0.0.tgz",
+      "integrity": "sha512-KLViCmWx94zOvpLwSlsx6yOCeMhZYaxrJV87Po5k/FoZzcPSahvK5qJ7fYhS61sZi5ikmh2S3Hz55A2l3U69ng==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react-reconciler": "^0.28.9"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0"
+      }
     },
     "node_modules/jiti": {
       "version": "2.7.0",
@@ -4772,6 +5117,15 @@
       "integrity": "sha512-S3kmBrptp3yRTm83NUcHy9g1vbwiWMzI8WvY22+koBJ6zkRteLnedBL2VX0MIAGwx2yiyxX4J85pceZyQ6ffgg==",
       "dev": true
     },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -4859,6 +5213,16 @@
         "lz-string": "bin/bin.js"
       }
     },
+    "node_modules/maath": {
+      "version": "0.10.8",
+      "resolved": "https://registry.npmjs.org/maath/-/maath-0.10.8.tgz",
+      "integrity": "sha512-tRvbDF0Pgqz+9XUa4jjfgAQ8/aPKmQdWXilFu2tMy4GWj4NOsx99HlULO4IeREfbO3a0sA145DZYyvXPkybm0g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/three": ">=0.134.0",
+        "three": ">=0.134.0"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -4876,6 +5240,21 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/meshline": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/meshline/-/meshline-3.3.1.tgz",
+      "integrity": "sha512-/TQj+JdZkeSUOl5Mk2J7eLcYTLiQm2IDzmlSvYm7ov15anEcDJ92GHqqazxTSreeNgfnYu24kiEvvv0WlbCdFQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.137"
+      }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-1.1.1.tgz",
+      "integrity": "sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==",
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -5166,7 +5545,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -5263,6 +5641,12 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/potpack": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
+      "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==",
+      "license": "ISC"
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -5298,6 +5682,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/promise-worker-transferable": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/promise-worker-transferable/-/promise-worker-transferable-1.0.4.tgz",
+      "integrity": "sha512-bN+0ehEnrXfxV2ZQvU2PetO0n4gqBD4ulq3MI1WOPLgr7/Mg9yRQkX5+0v1vagr74ZTsl7XtzlaYDo2EuCeYJw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "is-promise": "^2.1.0",
+        "lie": "^3.0.2"
       }
     },
     "node_modules/prop-types": {
@@ -5350,7 +5744,6 @@
       "version": "19.2.6",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5389,7 +5782,7 @@
       "version": "19.2.6",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
       "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5428,6 +5821,21 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-use-measure": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.1.7.tgz",
+      "integrity": "sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.13",
+        "react-dom": ">=16.13"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/recast": {
@@ -5469,6 +5877,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
@@ -5599,8 +6016,7 @@
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "dev": true
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -5615,7 +6031,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -5627,7 +6042,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -5679,6 +6093,32 @@
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true
+    },
+    "node_modules/stats-gl": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/stats-gl/-/stats-gl-2.4.2.tgz",
+      "integrity": "sha512-g5O9B0hm9CvnM36+v7SFl39T7hmAlv541tU81ME8YeSb3i1CIP5/QdDeSB3A0la0bKNHpxpwxOVRo2wFTYEosQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/three": "*",
+        "three": "^0.170.0"
+      },
+      "peerDependencies": {
+        "@types/three": "*",
+        "three": "*"
+      }
+    },
+    "node_modules/stats-gl/node_modules/three": {
+      "version": "0.170.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.170.0.tgz",
+      "integrity": "sha512-FQK+LEpYc0fBD+J8g6oSEyyNzjp+Q7Ks1C568WWaoMRLW+TkNNWmenWeGgJjV105Gd+p/2ql1ZcjYvNiPZBhuQ==",
+      "license": "MIT"
+    },
+    "node_modules/stats.js": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/stats.js/-/stats.js-0.17.0.tgz",
+      "integrity": "sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==",
+      "license": "MIT"
     },
     "node_modules/std-env": {
       "version": "4.1.0",
@@ -5810,6 +6250,53 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/suspend-react": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/suspend-react/-/suspend-react-0.1.3.tgz",
+      "integrity": "sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=17.0"
+      }
+    },
+    "node_modules/three": {
+      "version": "0.184.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.184.0.tgz",
+      "integrity": "sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==",
+      "license": "MIT"
+    },
+    "node_modules/three-mesh-bvh": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.8.3.tgz",
+      "integrity": "sha512-4G5lBaF+g2auKX3P0yqx+MJC6oVt6sB5k+CchS6Ob0qvH0YIhuUk1eYr7ktsIpY+albCqE80/FVQGV190PmiAg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">= 0.159.0"
+      }
+    },
+    "node_modules/three-stdlib": {
+      "version": "2.36.1",
+      "resolved": "https://registry.npmjs.org/three-stdlib/-/three-stdlib-2.36.1.tgz",
+      "integrity": "sha512-XyGQrFmNQ5O/IoKm556ftwKsBg11TIb301MB5dWNicziQBEs2g3gtOYIf7pFiLa0zI2gUwhtCjv9fmjnxKZ1Cg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/draco3d": "^1.4.0",
+        "@types/offscreencanvas": "^2019.6.4",
+        "@types/webxr": "^0.5.2",
+        "draco3d": "^1.4.1",
+        "fflate": "^0.6.9",
+        "potpack": "^1.0.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.128.0"
+      }
+    },
+    "node_modules/three-stdlib/node_modules/fflate": {
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.6.10.tgz",
+      "integrity": "sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==",
+      "license": "MIT"
+    },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
@@ -5877,6 +6364,36 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/troika-three-text": {
+      "version": "0.52.4",
+      "resolved": "https://registry.npmjs.org/troika-three-text/-/troika-three-text-0.52.4.tgz",
+      "integrity": "sha512-V50EwcYGruV5rUZ9F4aNsrytGdKcXKALjEtQXIOBfhVoZU9VAqZNIoGQ3TMiooVqFAbR1w15T+f+8gkzoFzawg==",
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.2",
+        "troika-three-utils": "^0.52.4",
+        "troika-worker-utils": "^0.52.0",
+        "webgl-sdf-generator": "1.1.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.125.0"
+      }
+    },
+    "node_modules/troika-three-utils": {
+      "version": "0.52.4",
+      "resolved": "https://registry.npmjs.org/troika-three-utils/-/troika-three-utils-0.52.4.tgz",
+      "integrity": "sha512-NORAStSVa/BDiG52Mfudk4j1FG4jC4ILutB3foPnfGbOeIs9+G5vZLa0pnmnaftZUGm4UwSoqEpWdqvC7zms3A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.125.0"
+      }
+    },
+    "node_modules/troika-worker-utils": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/troika-worker-utils/-/troika-worker-utils-0.52.0.tgz",
+      "integrity": "sha512-W1CpvTHykaPH5brv5VHLfQo9D1OYuo0cSBEUQFFT/nBUzM8iD6Lq2/tgG/f1OelbAS1WtaTPQzE5uM49egnngw==",
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -5917,6 +6434,43 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true
+    },
+    "node_modules/tunnel-rat": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tunnel-rat/-/tunnel-rat-0.1.2.tgz",
+      "integrity": "sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "zustand": "^4.3.2"
+      }
+    },
+    "node_modules/tunnel-rat/node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -6048,9 +6602,17 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
       "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
-      "dev": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/utility-types": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.11.0.tgz",
+      "integrity": "sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/validator": {
@@ -6370,6 +6932,17 @@
         "node": "20 || >=22"
       }
     },
+    "node_modules/webgl-constants": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-constants/-/webgl-constants-1.1.1.tgz",
+      "integrity": "sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg=="
+    },
+    "node_modules/webgl-sdf-generator": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-sdf-generator/-/webgl-sdf-generator-1.1.1.tgz",
+      "integrity": "sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA==",
+      "license": "MIT"
+    },
     "node_modules/webpack-virtual-modules": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
@@ -6389,7 +6962,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -6521,6 +7093,35 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.13.tgz",
+      "integrity": "sha512-efI2tVaVQPqtOh114loML/Z80Y4NP3yc+Ff0fYiZJPauNeWZeIp/bRFD7I9bfmCOYBh/PHxlglQ9+wvlwnPikQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
     "publish:ci": "npm run build && npm publish --access public"
   },
   "peerDependencies": {
+    "lucide-react": ">=0.400.0",
     "react": ">=18.0.0",
     "react-dom": ">=18.0.0",
-    "lucide-react": ">=0.400.0",
     "react-phone-number-input": ">=3.4.0"
   },
   "peerDependenciesMeta": {
@@ -52,6 +52,7 @@
     "@types/node": "^24.10.2",
     "@types/react": "^19.1.16",
     "@types/react-dom": "^19.1.9",
+    "@types/three": "^0.184.1",
     "@vitejs/plugin-react": "^5.0.4",
     "eslint": "^9.36.0",
     "eslint-plugin-react-hooks": "^5.2.0",
@@ -86,5 +87,10 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/vega-organisation/vegaReact.git"
+  },
+  "dependencies": {
+    "@react-three/drei": "^10.7.7",
+    "@react-three/fiber": "^9.6.1",
+    "three": "^0.184.0"
   }
 }

--- a/src/components/ModelViewer/ModelViewer.css
+++ b/src/components/ModelViewer/ModelViewer.css
@@ -1,0 +1,34 @@
+.vega-model-viewer {
+  position: relative;
+  overflow: hidden;
+  border-radius: 8px;
+}
+
+.vega-model-viewer__canvas {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.vega-model-viewer__overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+  background: transparent;
+}
+
+.vega-model-viewer__error {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+  font-family: var(--vega-font-family, system-ui, sans-serif);
+  font-size: 14px;
+  color: var(--vega-color-error, #d4351c);
+  text-align: center;
+}

--- a/src/components/ModelViewer/ModelViewer.stories.tsx
+++ b/src/components/ModelViewer/ModelViewer.stories.tsx
@@ -1,0 +1,267 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ModelViewer } from './ModelViewer';
+import type { ModelViewerEnvironment } from './ModelViewer.types';
+import { Button } from '../Button';
+import { Checkbox } from '../Checkbox';
+import { Card } from '../Card';
+
+const SAMPLE_MODEL =
+  'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/DamagedHelmet/glTF-Binary/DamagedHelmet.glb';
+
+const meta: Meta<typeof ModelViewer> = {
+  title: 'Components/ModelViewer',
+  component: ModelViewer,
+  parameters: { layout: 'centered' },
+  argTypes: {
+    environment: {
+      control: 'select',
+      options: [
+        'studio',
+        'city',
+        'sunset',
+        'warehouse',
+        'forest',
+        'apartment',
+        'park',
+        'lobby',
+        'night',
+        'dawn',
+      ],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ModelViewer>;
+
+export const Default: Story = {
+  args: {
+    src: SAMPLE_MODEL,
+    width: 480,
+    height: 360,
+  },
+};
+
+export const AutoRotate: Story = {
+  args: {
+    src: SAMPLE_MODEL,
+    width: 480,
+    height: 360,
+    autoRotate: true,
+    autoRotateSpeed: 1.5,
+  },
+};
+
+export const MouseParallax: Story = {
+  args: {
+    src: SAMPLE_MODEL,
+    width: 480,
+    height: 360,
+    mouseParallax: true,
+    mouseParallaxIntensity: 0.3,
+    orbit: false,
+    zoom: false,
+  },
+};
+
+export const RotatedAndScaled: Story = {
+  args: {
+    src: SAMPLE_MODEL,
+    width: 480,
+    height: 360,
+    rotation: [0, 45, 0],
+    scale: 1.2,
+  },
+};
+
+export const SunsetEnvironment: Story = {
+  args: {
+    src: SAMPLE_MODEL,
+    width: 480,
+    height: 360,
+    environment: 'sunset',
+    background: '#1a0f2e',
+  },
+};
+
+export const NoControls: Story = {
+  args: {
+    src: SAMPLE_MODEL,
+    width: 480,
+    height: 360,
+    orbit: false,
+    zoom: false,
+    pan: false,
+  },
+};
+
+const ENVIRONMENTS: ModelViewerEnvironment[] = [
+  'studio',
+  'city',
+  'sunset',
+  'warehouse',
+  'night',
+  'dawn',
+];
+
+function Playground() {
+  const [orbit, setOrbit] = useState(true);
+  const [zoom, setZoom] = useState(true);
+  const [pan, setPan] = useState(false);
+  const [autoRotate, setAutoRotate] = useState(false);
+  const [parallax, setParallax] = useState(false);
+  const [environment, setEnvironment] = useState<ModelViewerEnvironment>('studio');
+  const [scale, setScale] = useState(1);
+  const [rotationY, setRotationY] = useState(0);
+
+  const reset = () => {
+    setOrbit(true);
+    setZoom(true);
+    setPan(false);
+    setAutoRotate(false);
+    setParallax(false);
+    setEnvironment('studio');
+    setScale(1);
+    setRotationY(0);
+  };
+
+  return (
+    <div style={{ display: 'flex', gap: 24, alignItems: 'flex-start' }}>
+      <ModelViewer
+        src={SAMPLE_MODEL}
+        width={480}
+        height={360}
+        orbit={orbit}
+        zoom={zoom}
+        pan={pan}
+        autoRotate={autoRotate}
+        mouseParallax={parallax}
+        mouseParallaxIntensity={0.3}
+        environment={environment}
+        scale={scale}
+        rotation={[0, rotationY, 0]}
+      />
+
+      <Card variant="elevated" style={{ width: 280 }}>
+        <Card.Header>
+          <strong>3D Playground</strong>
+        </Card.Header>
+
+        <Card.Body>
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 16,
+            }}
+          >
+            <section>
+              <div style={{ fontSize: 12, fontWeight: 600, marginBottom: 8 }}>
+                Interactions
+              </div>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                <Checkbox
+                  label="Orbit"
+                  checked={orbit}
+                  onChange={(e) => setOrbit(e.target.checked)}
+                />
+                <Checkbox
+                  label="Zoom"
+                  checked={zoom}
+                  onChange={(e) => setZoom(e.target.checked)}
+                />
+                <Checkbox
+                  label="Pan"
+                  checked={pan}
+                  onChange={(e) => setPan(e.target.checked)}
+                />
+                <Checkbox
+                  label="Auto-rotate"
+                  checked={autoRotate}
+                  onChange={(e) => setAutoRotate(e.target.checked)}
+                />
+                <Checkbox
+                  label="Mouse parallax"
+                  checked={parallax}
+                  onChange={(e) => setParallax(e.target.checked)}
+                />
+              </div>
+            </section>
+
+            <section>
+              <div style={{ fontSize: 12, fontWeight: 600, marginBottom: 8 }}>
+                Environment
+              </div>
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+                {ENVIRONMENTS.map((env) => (
+                  <Button
+                    key={env}
+                    size="small"
+                    variant={environment === env ? 'primary' : 'secondary'}
+                    onClick={() => setEnvironment(env)}
+                  >
+                    {env}
+                  </Button>
+                ))}
+              </div>
+            </section>
+
+            <section>
+              <div style={{ fontSize: 12, fontWeight: 600, marginBottom: 8 }}>
+                Scale: {scale.toFixed(2)}×
+              </div>
+              <div style={{ display: 'flex', gap: 6 }}>
+                <Button
+                  size="small"
+                  variant="secondary"
+                  onClick={() => setScale((s) => Math.max(0.25, s - 0.25))}
+                >
+                  −
+                </Button>
+                <Button
+                  size="small"
+                  variant="secondary"
+                  onClick={() => setScale((s) => Math.min(4, s + 0.25))}
+                >
+                  +
+                </Button>
+              </div>
+            </section>
+
+            <section>
+              <div style={{ fontSize: 12, fontWeight: 600, marginBottom: 8 }}>
+                Rotation Y: {rotationY}°
+              </div>
+              <div style={{ display: 'flex', gap: 6 }}>
+                <Button
+                  size="small"
+                  variant="secondary"
+                  onClick={() => setRotationY((r) => r - 45)}
+                >
+                  − 45°
+                </Button>
+                <Button
+                  size="small"
+                  variant="secondary"
+                  onClick={() => setRotationY((r) => r + 45)}
+                >
+                  + 45°
+                </Button>
+              </div>
+            </section>
+
+            <Button variant="danger" size="small" fullWidth onClick={reset}>
+              Reset
+            </Button>
+          </div>
+        </Card.Body>
+      </Card>
+    </div>
+  );
+}
+
+export const InteractivePlayground: Story = {
+  parameters: { layout: 'padded' },
+  render: () => <Playground />,
+};

--- a/src/components/ModelViewer/ModelViewer.test.tsx
+++ b/src/components/ModelViewer/ModelViewer.test.tsx
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { ModelViewer } from './ModelViewer';
+
+vi.mock('@react-three/fiber', () => ({
+  Canvas: ({ className }: { className?: string }) => (
+    <div data-testid="r3f-canvas" className={className} />
+  ),
+  useFrame: vi.fn(),
+}));
+
+vi.mock('@react-three/drei', () => ({
+  Bounds: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  Environment: () => null,
+  OrbitControls: () => null,
+  useGLTF: () => ({ scene: {} }),
+  useProgress: () => ({ active: false, progress: 100, errors: [], item: '', loaded: 0, total: 0 }),
+}));
+
+describe('ModelViewer', () => {
+  it('renders the wrapper element', () => {
+    const { container } = render(<ModelViewer src="model.glb" />);
+    expect(container.querySelector('.vega-model-viewer')).toBeInTheDocument();
+  });
+
+  it('applies a custom className', () => {
+    const { container } = render(
+      <ModelViewer src="model.glb" className="my-viewer" />,
+    );
+    expect(container.querySelector('.vega-model-viewer')).toHaveClass('my-viewer');
+  });
+
+  it('applies width and height as inline styles', () => {
+    const { container } = render(
+      <ModelViewer src="model.glb" width={500} height={300} />,
+    );
+    const wrapper = container.querySelector('.vega-model-viewer') as HTMLElement;
+    expect(wrapper.style.width).toBe('500px');
+    expect(wrapper.style.height).toBe('300px');
+  });
+
+  it('renders the canvas element', () => {
+    const { getByTestId } = render(<ModelViewer src="model.glb" />);
+    expect(getByTestId('r3f-canvas')).toBeInTheDocument();
+  });
+
+  it('hides the loading overlay when not active', () => {
+    const { container } = render(<ModelViewer src="model.glb" />);
+    expect(container.querySelector('.vega-model-viewer__overlay')).toBeNull();
+  });
+
+  it('uses transparent background by default', () => {
+    const { container } = render(<ModelViewer src="model.glb" />);
+    const wrapper = container.querySelector('.vega-model-viewer') as HTMLElement;
+    expect(wrapper.style.background).toBe('transparent');
+  });
+});

--- a/src/components/ModelViewer/ModelViewer.tsx
+++ b/src/components/ModelViewer/ModelViewer.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Component, Suspense, useEffect, useRef } from 'react';
-import type { CSSProperties, ErrorInfo, ReactNode } from 'react';
+import type { CSSProperties, ReactNode } from 'react';
 import { Canvas, useFrame } from '@react-three/fiber';
 import {
   Bounds,
@@ -109,7 +109,7 @@ class ModelErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryStat
     return { error };
   }
 
-  componentDidCatch(error: Error, _info: ErrorInfo): void {
+  componentDidCatch(error: Error): void {
     this.props.onError?.(error);
   }
 

--- a/src/components/ModelViewer/ModelViewer.tsx
+++ b/src/components/ModelViewer/ModelViewer.tsx
@@ -1,0 +1,222 @@
+'use client';
+
+import { Component, Suspense, useEffect, useRef } from 'react';
+import type { CSSProperties, ErrorInfo, ReactNode } from 'react';
+import { Canvas, useFrame } from '@react-three/fiber';
+import {
+  Bounds,
+  Environment,
+  OrbitControls,
+  useGLTF,
+  useProgress,
+} from '@react-three/drei';
+import { MathUtils } from 'three';
+import type { Group } from 'three';
+import { Loader } from '../Loader';
+import type { ModelViewerProps } from './ModelViewer.types';
+import './ModelViewer.css';
+
+interface ModelProps {
+  src: string;
+  scale: number | [number, number, number];
+  rotation: [number, number, number];
+  position: [number, number, number];
+  mouseParallax: boolean;
+  mouseParallaxIntensity: number;
+  onLoad?: () => void;
+  onClick?: () => void;
+}
+
+function Model({
+  src,
+  scale,
+  rotation,
+  position,
+  mouseParallax,
+  mouseParallaxIntensity,
+  onLoad,
+  onClick,
+}: ModelProps) {
+  const { scene } = useGLTF(src);
+  const groupRef = useRef<Group>(null);
+  const target = useRef({ x: 0, y: 0 });
+
+  useEffect(() => {
+    onLoad?.();
+  }, [src, onLoad]);
+
+  useEffect(() => {
+    if (!mouseParallax) return;
+    const handler = (e: PointerEvent) => {
+      target.current.x = (e.clientX / window.innerWidth) * 2 - 1;
+      target.current.y = (e.clientY / window.innerHeight) * 2 - 1;
+    };
+    window.addEventListener('pointermove', handler);
+    return () => window.removeEventListener('pointermove', handler);
+  }, [mouseParallax]);
+
+  const baseRotation: [number, number, number] = [
+    MathUtils.degToRad(rotation[0]),
+    MathUtils.degToRad(rotation[1]),
+    MathUtils.degToRad(rotation[2]),
+  ];
+
+  useFrame(() => {
+    if (!groupRef.current || !mouseParallax) return;
+    const targetY = baseRotation[1] + target.current.x * mouseParallaxIntensity;
+    const targetX = baseRotation[0] - target.current.y * mouseParallaxIntensity;
+    groupRef.current.rotation.y += (targetY - groupRef.current.rotation.y) * 0.08;
+    groupRef.current.rotation.x += (targetX - groupRef.current.rotation.x) * 0.08;
+  });
+
+  const scaleVec: [number, number, number] =
+    typeof scale === 'number' ? [scale, scale, scale] : scale;
+
+  return (
+    <group
+      ref={groupRef}
+      rotation={mouseParallax ? undefined : baseRotation}
+      position={position}
+      scale={scaleVec}
+      onClick={
+        onClick
+          ? (e) => {
+              e.stopPropagation();
+              onClick();
+            }
+          : undefined
+      }
+    >
+      <primitive object={scene} />
+    </group>
+  );
+}
+
+interface ErrorBoundaryProps {
+  fallback: ReactNode;
+  onError?: (err: Error) => void;
+  children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+}
+
+class ModelErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, _info: ErrorInfo): void {
+    this.props.onError?.(error);
+  }
+
+  render() {
+    if (this.state.error) return this.props.fallback;
+    return this.props.children;
+  }
+}
+
+function LoadingOverlay({ fallback }: { fallback: ReactNode }) {
+  const { active } = useProgress();
+  if (!active) return null;
+  return <div className="vega-model-viewer__overlay">{fallback}</div>;
+}
+
+export function ModelViewer({
+  src,
+  width = '100%',
+  height = 400,
+  scale = 1,
+  rotation = [0, 0, 0],
+  position = [0, 0, 0],
+  cameraPosition,
+  cameraFov = 50,
+  autoFrame = true,
+  orbit = true,
+  zoom = true,
+  pan = false,
+  autoRotate = false,
+  autoRotateSpeed = 1,
+  mouseParallax = false,
+  mouseParallaxIntensity = 0.1,
+  environment = 'studio',
+  background,
+  loadingFallback,
+  errorFallback,
+  onLoad,
+  onError,
+  onClick,
+  className,
+  style,
+}: ModelViewerProps) {
+  const wrapperStyle: CSSProperties = {
+    width,
+    height,
+    background: background ?? 'transparent',
+    ...style,
+  };
+
+  const containerClass = ['vega-model-viewer', className].filter(Boolean).join(' ');
+
+  const errorNode = errorFallback ?? (
+    <div className="vega-model-viewer__error">Failed to load 3D model.</div>
+  );
+
+  const loadingNode = loadingFallback ?? <Loader />;
+  const fitCamera = autoFrame && !cameraPosition;
+  const cameraConfig = {
+    position: cameraPosition ?? ([0, 0, 5] as [number, number, number]),
+    fov: cameraFov,
+  };
+  const controlsEnabled = orbit || zoom || pan || autoRotate;
+
+  const modelNode = (
+    <Model
+      src={src}
+      scale={scale}
+      rotation={rotation}
+      position={position}
+      mouseParallax={mouseParallax}
+      mouseParallaxIntensity={mouseParallaxIntensity}
+      onLoad={onLoad}
+      onClick={onClick}
+    />
+  );
+
+  return (
+    <div className={containerClass} style={wrapperStyle}>
+      <ModelErrorBoundary fallback={errorNode} onError={onError}>
+        <Canvas
+          className="vega-model-viewer__canvas"
+          camera={cameraConfig}
+          gl={{ alpha: !background }}
+        >
+          <Suspense fallback={null}>
+            <Environment preset={environment} />
+            {fitCamera ? (
+              <Bounds key={src} fit clip margin={1.2}>
+                {modelNode}
+              </Bounds>
+            ) : (
+              modelNode
+            )}
+            {controlsEnabled && (
+              <OrbitControls
+                enableRotate={orbit}
+                enableZoom={zoom}
+                enablePan={pan}
+                autoRotate={autoRotate}
+                autoRotateSpeed={autoRotateSpeed}
+                makeDefault
+              />
+            )}
+          </Suspense>
+        </Canvas>
+      </ModelErrorBoundary>
+      <LoadingOverlay fallback={loadingNode} />
+    </div>
+  );
+}

--- a/src/components/ModelViewer/ModelViewer.types.ts
+++ b/src/components/ModelViewer/ModelViewer.types.ts
@@ -1,0 +1,73 @@
+import type { CSSProperties, ReactNode } from 'react';
+
+export type ModelViewerEnvironment =
+  | 'studio'
+  | 'city'
+  | 'sunset'
+  | 'warehouse'
+  | 'forest'
+  | 'apartment'
+  | 'park'
+  | 'lobby'
+  | 'night'
+  | 'dawn';
+
+export interface ModelViewerProps {
+  /** URL of the .gltf or .glb model to load. */
+  src: string;
+
+  /** Canvas width. Number → pixels, string → any CSS unit. Default `'100%'`. */
+  width?: number | string;
+  /** Canvas height. Number → pixels, string → any CSS unit. Default `400`. */
+  height?: number | string;
+
+  /** Uniform or per-axis scale applied to the loaded model. Default `1`. */
+  scale?: number | [number, number, number];
+  /** Rotation of the model in **degrees** [x, y, z]. Default `[0, 0, 0]`. */
+  rotation?: [number, number, number];
+  /** Position offset of the model. Default `[0, 0, 0]`. */
+  position?: [number, number, number];
+
+  /** Camera position. When provided, disables `autoFrame`. */
+  cameraPosition?: [number, number, number];
+  /** Camera field of view (degrees). Default `50`. */
+  cameraFov?: number;
+  /** Auto-fit the camera to the model's bounding box on load. Default `true`. */
+  autoFrame?: boolean;
+
+  /** Enable click-drag rotation. Default `true`. */
+  orbit?: boolean;
+  /** Enable mouse-wheel zoom. Default `true`. */
+  zoom?: boolean;
+  /** Enable right-click drag panning. Default `false`. */
+  pan?: boolean;
+  /** Continuously rotate the camera around the model. Default `false`. */
+  autoRotate?: boolean;
+  /** Auto-rotation speed (drei units). Default `1`. */
+  autoRotateSpeed?: number;
+
+  /** Subtle parallax: model tilts toward the mouse cursor. Default `false`. */
+  mouseParallax?: boolean;
+  /** Parallax intensity (0–1 reasonable range). Default `0.1`. */
+  mouseParallaxIntensity?: number;
+
+  /** Drei HDR environment preset for PBR lighting. Default `'studio'`. */
+  environment?: ModelViewerEnvironment;
+  /** Solid background color. Default `undefined` (transparent canvas). */
+  background?: string;
+
+  /** Custom node shown while the model loads. Default `<Loader />`. */
+  loadingFallback?: ReactNode;
+  /** Custom node shown when loading fails. Default = simple text. */
+  errorFallback?: ReactNode;
+
+  /** Fired once the model has finished loading. */
+  onLoad?: () => void;
+  /** Fired when loading or parsing fails. */
+  onError?: (error: Error) => void;
+  /** Fired when the user clicks on the model. */
+  onClick?: () => void;
+
+  className?: string;
+  style?: CSSProperties;
+}

--- a/src/components/ModelViewer/index.ts
+++ b/src/components/ModelViewer/index.ts
@@ -1,0 +1,5 @@
+export { ModelViewer } from './ModelViewer';
+export type {
+  ModelViewerProps,
+  ModelViewerEnvironment,
+} from './ModelViewer.types';

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,3 +49,8 @@ export type {
 } from "./components/Tooltip/Tooltip.types";
 export { FormWrapper, useFormContext } from "./components/FormWrapper";
 export type { FormWrapperProps, FormContextValue, FormWrapperGap } from "./components/FormWrapper/FormWrapper.types";
+export { ModelViewer } from "./components/ModelViewer";
+export type {
+  ModelViewerProps,
+  ModelViewerEnvironment,
+} from "./components/ModelViewer/ModelViewer.types";


### PR DESCRIPTION
closes #84

## Description

New `ModelViewer` component to render a `.gltf` / `.glb` model in an interactive 3D canvas, built on `@react-three/fiber` + `@react-three/drei` + `three` (bundled as regular deps).

### API highlights

| Prop | Default | Notes |
|---|---|---|
| `src` | — | URL of the model (required) |
| `width` / `height` | `'100%'` / `400` | Canvas dimensions |
| `scale` | `1` | Uniform or `[x,y,z]` |
| `rotation` | `[0,0,0]` | **Degrees** (converted to radians internally) |
| `position` | `[0,0,0]` | World position |
| `cameraPosition` / `cameraFov` | auto / `50` | Overrides auto-frame when set |
| `autoFrame` | `true` | Fits camera once on initial load |
| `orbit` / `zoom` / `pan` | `true` / `true` / `false` | OrbitControls toggles |
| `autoRotate` / `autoRotateSpeed` | `false` / `1` | Showcase auto-rotation |
| `mouseParallax` / `mouseParallaxIntensity` | `false` / `0.1` | Subtle tilt of the model toward cursor (does not fight OrbitControls — applied to the model, not the camera) |
| `environment` | `'studio'` | drei HDR preset |
| `background` | `undefined` | Transparent canvas by default |
| `loadingFallback` / `errorFallback` | `<Loader />` / text | Customizable |
| `onLoad` / `onError` / `onClick` | — | Standard callbacks |

### Auto-frame fix

Initial draft used `<Bounds fit clip observe>`, but `observe` made the camera re-fit on every scale/rotation change — so `scale` had no visible effect. Switched to `<Bounds key={src} fit clip>` which fits once and remounts only when the source URL changes.

### Storybook

7 stories: `Default`, `AutoRotate`, `MouseParallax`, `RotatedAndScaled`, `SunsetEnvironment`, `NoControls`, plus an `InteractivePlayground` with a Card-based control panel (Checkbox + Button) for live tweaking.

## Testing

- [x] `npm run build` — clean, no TS errors
- [x] `npm test -- src/components/ModelViewer` — 6/6 passing (R3F + drei mocked, wrapper DOM verified)
- [ ] Visual check via Storybook on each story
- [ ] Verify on a consumer app that `import { ModelViewer } from 'vega-react-components'` works after publish

## Notes

- Bundle size now ~2.1 MB (~478 KB gzip) due to three.js + drei. This was an explicit decision (deps bundled rather than peer). If we later want to make 3D opt-in, we can move `three` / `@react-three/*` to optional peer deps similar to `react-phone-number-input`.