### PR TITLE
docs: add wiki source pages #88

### DIFF
--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -1,0 +1,87 @@
+# Architecture
+
+## Folder structure
+
+```
+src/
+├── assets/styles/         # Global CSS — tokens, typography
+│   ├── tokens.css         # Colors, borders, backgrounds
+│   └── typography.css     # Font sizes, weights
+├── components/            # One folder per component (5-file convention)
+│   ├── Button/
+│   ├── Card/
+│   └── ...
+└── index.ts               # Public API — exports all components and types
+```
+
+## Build & distribution
+
+- **Bundler**: Vite 7 (library mode) + `vite-plugin-dts` for type declarations
+- **Output**: dual format — `dist/vegareact.es.js` (ESM) + `dist/vegareact.cjs.js` (CJS)
+- **Types**: `dist/index.d.ts`
+- **CSS**: bundled to `dist/style.css`, exported as `vega-react-components/style.css`
+- **`"use client"`** directive at the top of `src/index.ts` for Next.js / RSC compatibility
+
+## Design tokens
+
+All visual values come from CSS custom properties in `src/assets/styles/tokens.css`. Components must reference these tokens — no hardcoded colors, spacing, or fonts.
+
+### Colors
+
+| Token | Value | Usage |
+|-------|-------|-------|
+| `--color-primary` | `#6d28d9` | Primary actions |
+| `--color-secondary` | `#e5e7eb` | Secondary actions |
+| `--color-error` | `#ef4444` | Error states |
+| `--color-success` | `#22c55e` | Success states |
+| `--bg-surface` | `#ffffff` | Component backgrounds |
+| `--bg-disabled` | `#f3f4f6` | Disabled backgrounds |
+| `--text-main` | `#111827` | Primary text |
+| `--text-secondary` | `#9ca3af` | Secondary text / placeholders |
+| `--text-inverse` | `#ffffff` | Text on dark backgrounds |
+| `--border-default` | `#d1d5db` | Default borders |
+| `--border-focus` | `#111827` | Focus borders |
+| `--border-error` | `#ef4444` | Error borders |
+| `--border-success` | `#22c55e` | Success borders |
+
+### Typography
+
+- **Sizes**: `--text-xs` (12px), `--text-sm` (14px), `--text-base` (16px), `--text-md` (18px), `--text-lg` (20px), `--text-xl` (24px)
+- **Weights**: `--font-light` (300), `--font-normal` (400), `--font-medium` (500), `--font-semibold` (600), `--font-bold` (700)
+
+## CSS conventions
+
+- **BEM-style** naming: `.mycomponent`, `.mycomponent--variant`, `.mycomponent__element`
+- **Size variants**: `--small`, `--medium`, `--large`
+- **Status variants**: `--default`, `--error`, `--success`
+- **State variants**: `--disabled`, `--full-width`
+- Use `:focus-visible` for keyboard focus styles
+- Animations: `transition: ... 0.2s ease`
+
+## TypeScript
+
+- **Strict mode** enabled
+- `noUnusedLocals` and `noUnusedParameters` enforced
+- `verbatimModuleSyntax: true` — use `import type` for type-only imports
+- `erasableSyntaxOnly: true` — no `const enum`, no legacy decorators
+
+## Scripts
+
+```bash
+npm run storybook        # Storybook dev server (port 6006)
+npm run build            # tsc + Vite build
+npm run lint             # ESLint
+npm run test             # Vitest (run once)
+npm run test:watch       # Vitest watch mode
+npm run knip             # Detect unused exports/files
+npm run build-storybook  # Static Storybook build
+```
+
+## CI pipeline
+
+PRs to `main` run:
+1. **Knip** — unused-code detection
+2. **ESLint** — TS + React rules
+3. **Build Storybook** — verifies compilation
+
+Workflows use `npm install --legacy-peer-deps`.

--- a/wiki/Button.md
+++ b/wiki/Button.md
@@ -1,0 +1,55 @@
+# Button
+
+Clickable action element with multiple variants and sizes.
+
+## Import
+
+```tsx
+import { Button } from "vega-react-components";
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `children` | `ReactNode` | — | Button content (required). |
+| `variant` | `'primary' \| 'secondary' \| 'danger' \| 'success'` | `'primary'` | Visual style. |
+| `size` | `'small' \| 'medium' \| 'large'` | `'medium'` | Button size. |
+| `fullWidth` | `boolean` | `false` | Stretch to fill parent width. |
+| ...rest | `ButtonHTMLAttributes<HTMLButtonElement>` | — | Standard HTML button attributes (`onClick`, `disabled`, `type`, etc.). |
+
+## Examples
+
+### Variants
+
+```tsx
+<Button variant="primary">Primary</Button>
+<Button variant="secondary">Secondary</Button>
+<Button variant="danger">Delete</Button>
+<Button variant="success">Confirm</Button>
+```
+
+### Sizes
+
+```tsx
+<Button size="small">Small</Button>
+<Button size="medium">Medium</Button>
+<Button size="large">Large</Button>
+```
+
+### Full width
+
+```tsx
+<Button fullWidth>Submit</Button>
+```
+
+### Disabled
+
+```tsx
+<Button disabled>Unavailable</Button>
+```
+
+## See also
+
+- [Components](Components) — full component list
+- Storybook: `Components/Button` (run `npm run storybook`)

--- a/wiki/CI-CD.md
+++ b/wiki/CI-CD.md
@@ -1,0 +1,82 @@
+# CI / CD
+
+Three GitHub Actions workflows live under `.github/workflows/`:
+
+| Workflow | Trigger | Purpose |
+|----------|---------|---------|
+| `pr-validation.yml` | Pull request opened / edited / sync'd | Enforces PR title + body conventions |
+| `build.yml` | Pull request to `main` | Runs the full build chain (knip → lint → tsc → test → storybook) |
+| `publish.yml` | Manual (`workflow_dispatch`) | Publishes the package to npm |
+
+## PR Validation
+
+**File**: `.github/workflows/pr-validation.yml`
+
+Fails the PR if any of the following is missing:
+
+1. **Title prefix** — one of `feat:`, `fix:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, `chore:`, `ci:`
+2. **Linked issue** in the body — `fixes #`, `closes #`, or `resolves #`
+3. **`## Description`** section in the body
+4. **`## Testing`** section in the body
+
+See [Pull Requests](Pull-Requests) for the recommended template.
+
+## Build
+
+**File**: `.github/workflows/build.yml`
+**Triggered**: every PR to `main`
+**Runtime**: `ubuntu-latest`, **Node 24**
+
+Steps (in order — fails fast on first error):
+
+| # | Step | Command | Purpose |
+|---|------|---------|---------|
+| 1 | Install | `npm ci` | Clean install from `package-lock.json` |
+| 2 | Declutter | `npm run knip` | Detects unused files / exports / types |
+| 3 | Lint | `npm run lint` | ESLint with TypeScript + React rules |
+| 4 | Type-check | `npx tsc --noEmit` | Type validation without emitting |
+| 5 | Test | `npm run test` | Vitest (run once, not watch) |
+| 6 | Build Storybook | `npm run build-storybook` | Verifies the library + stories compile |
+
+All six steps must pass for a PR to be mergeable.
+
+### Running the same chain locally
+
+```bash
+npm ci
+npm run knip
+npm run lint
+npx tsc --noEmit
+npm run test
+npm run build-storybook
+```
+
+Run this before pushing to avoid red CI builds.
+
+## Publish to npm
+
+**File**: `.github/workflows/publish.yml`
+**Triggered**: **manually** via `workflow_dispatch` from the Actions tab
+
+Steps:
+
+1. Checkout
+2. Setup Node 24 with the npm registry
+3. `npm ci`
+4. `npm run build` (TypeScript + Vite library build)
+5. `npm publish --provenance --access public`
+   - Uses `NPM_TOKEN` secret as `NODE_AUTH_TOKEN`
+   - `--provenance` produces an [npm provenance attestation](https://docs.npmjs.com/generating-provenance-statements) tied to the GitHub Actions run
+
+The job has `permissions: id-token: write` so npm provenance can use OIDC.
+
+See [Release Process](Release-Process) for who triggers this and when.
+
+## Adding a new workflow
+
+If you need a new check, add a file under `.github/workflows/`. Keep these conventions:
+
+- Use `actions/checkout@v4`, `actions/setup-node@v4` (current versions in the repo)
+- Pin `node-version` to `24` unless there's a reason to differ
+- Prefer `npm ci` over `npm install` for reproducibility
+- If the workflow blocks merges, add it to the branch protection rules on `main`

--- a/wiki/Card.md
+++ b/wiki/Card.md
@@ -1,0 +1,81 @@
+# Card
+
+Container component for grouping content. Composes with `Card.Media`, `Card.Header`, `Card.Body`, `Card.Footer`.
+
+## Import
+
+```tsx
+import { Card } from "vega-react-components";
+```
+
+## `Card` props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `variant` | `'default' \| 'elevated' \| 'outlined' \| 'interactive'` | `'default'` | Visual style. |
+| `onClick` | `() => void` | — | Makes the card clickable (adds `role="button"` and keyboard support). |
+| `children` | `ReactNode` | — | Card content. |
+| `className` | `string` | — | Extra class on the root. |
+| ...rest | `HTMLAttributes<HTMLDivElement>` | — | Standard div attributes. |
+
+## Sub-components
+
+### `Card.Media`
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `src` | `string` | — | **Required.** Image URL. |
+| `alt` | `string` | `""` | Alt text. |
+| `ratio` | `'16/9' \| '4/3' \| '1/1' \| '3/4'` | `'16/9'` | Aspect ratio of the media area. |
+| `className` | `string` | — | Extra class. |
+
+### `Card.Header` / `Card.Body` / `Card.Footer`
+
+All accept `children`, `className`, and any `HTMLAttributes<HTMLDivElement>`.
+
+## Examples
+
+### Basic
+
+```tsx
+<Card>
+  <Card.Body>Simple card with body only.</Card.Body>
+</Card>
+```
+
+### Full composition
+
+```tsx
+<Card variant="elevated">
+  <Card.Media src="/hero.jpg" alt="Mountain view" ratio="16/9" />
+  <Card.Header>
+    <h3>Trip to the Alps</h3>
+  </Card.Header>
+  <Card.Body>
+    Three days of hiking through alpine meadows.
+  </Card.Body>
+  <Card.Footer>
+    <Button variant="primary">Book now</Button>
+  </Card.Footer>
+</Card>
+```
+
+### Interactive (clickable) card
+
+```tsx
+<Card variant="interactive" onClick={() => navigate("/post/42")}>
+  <Card.Body>Click anywhere to open the post.</Card.Body>
+</Card>
+```
+
+### Outlined
+
+```tsx
+<Card variant="outlined">
+  <Card.Body>Minimal style with a border.</Card.Body>
+</Card>
+```
+
+## See also
+
+- [Components](Components) — full component list

--- a/wiki/Checkbox.md
+++ b/wiki/Checkbox.md
@@ -1,0 +1,66 @@
+# Checkbox
+
+Selectable input for boolean values, supporting `indeterminate` state and an optional description.
+
+## Import
+
+```tsx
+import { Checkbox } from "vega-react-components";
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `label` | `ReactNode` | — | Label rendered next to the checkbox. |
+| `description` | `ReactNode` | — | Secondary text under the label. |
+| `size` | `'small' \| 'medium' \| 'large'` | `'medium'` | Checkbox size. |
+| `indeterminate` | `boolean` | `false` | Renders the indeterminate (`–`) state. |
+| `error` | `string` | — | Error message; renders below in the error color. |
+| `fullWidth` | `boolean` | `false` | Stretch to fill parent width. |
+| ...rest | `InputHTMLAttributes<HTMLInputElement>` (without `size`, `type`) | — | Standard HTML input attributes (`checked`, `onChange`, `disabled`, etc.). |
+
+## Examples
+
+### Basic
+
+```tsx
+<Checkbox label="Accept terms" />
+```
+
+### Controlled
+
+```tsx
+const [checked, setChecked] = useState(false);
+
+<Checkbox
+  label="Subscribe to newsletter"
+  checked={checked}
+  onChange={(e) => setChecked(e.target.checked)}
+/>
+```
+
+### With description
+
+```tsx
+<Checkbox
+  label="Marketing emails"
+  description="Get occasional product updates and tips."
+/>
+```
+
+### Indeterminate
+
+```tsx
+<Checkbox label="Select all" indeterminate />
+```
+
+### With error
+
+```tsx
+<Checkbox label="I agree" error="You must accept the terms to continue" />
+```
+
+## See also
+
+- [Components](Components) — full component list

--- a/wiki/Components.md
+++ b/wiki/Components.md
@@ -1,0 +1,48 @@
+# Components
+
+All components exported by `vega-react-components`. Click a component name for its detailed page.
+
+## Forms
+
+| Component | Description |
+|-----------|-------------|
+| [Button](Button) | Clickable action element with multiple variants and states. |
+| [Checkbox](Checkbox) | Selectable input for boolean or multi-choice values. |
+| [InputText](InputText) | Basic text input with label and validation support. |
+| [InputEmail](InputEmail) | Text input with built-in email format validation. |
+| [PhoneNumberInput](PhoneNumberInput) | Phone input with country code selection and formatting. |
+| [FormWrapper](FormWrapper) | Global form state, validation, and submission handling. |
+
+## Feedback
+
+| Component | Description |
+|-----------|-------------|
+| [Loader](Loader) | Loading indicator (spinner, skeleton, progress bar) for async states. |
+| [Toast](Toast) | Auto-dismissing notification system for transient messages. |
+
+## Layout
+
+| Component | Description |
+|-----------|-------------|
+| [Card](Card) | Container with variants and composition for grouping content. |
+| [Sidebar](Sidebar) | Vertical navigation panel with header / body / footer composition. |
+| [Navbar](Navbar) | Top navigation bar with logo, items, and responsive hamburger menu. |
+
+## Overlay
+
+| Component | Description |
+|-----------|-------------|
+| [Dialog](Dialog) | Modal window with focus trap and accessibility built-in. |
+| [Tooltip](Tooltip) | Contextual hint displayed on hover or focus. |
+| [ContextMenu](ContextMenu) | Right-click menu with custom actions. |
+
+## Media
+
+| Component | Description |
+|-----------|-------------|
+| [ModelViewer](ModelViewer) | 3D model viewer (glTF/GLB) built on @react-three/fiber. |
+
+## See also
+
+- [Getting Started](Getting-Started) for installation
+- Storybook (`npm run storybook`) for live interactive demos

--- a/wiki/ContextMenu.md
+++ b/wiki/ContextMenu.md
@@ -1,0 +1,55 @@
+# ContextMenu
+
+Right-click menu with custom actions. Wraps any element and opens a contextual menu on right-click.
+
+## Import
+
+```tsx
+import { ContextMenu } from "vega-react-components";
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `children` | `ReactNode` | — | **Required.** The element that triggers the menu on right-click. |
+| `items` | `{ icon: string; label: string; onClick: (e) => void }[]` | — | Menu entries. |
+| `disabled` | `boolean` | `false` | Disables the menu (right-click does nothing). |
+| `onClick` | `(event: MouseEvent<HTMLDivElement>) => void` | — | Click handler on the wrapper element. |
+| `className` | `string` | — | Extra class on the wrapper. |
+
+### Item shape
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `icon` | `string` | Icon identifier (string — see component source for supported values). |
+| `label` | `string` | Menu label. |
+| `onClick` | `(e: MouseEvent<HTMLDivElement>) => void` | Fired when the entry is clicked. |
+
+## Examples
+
+### Basic
+
+```tsx
+<ContextMenu
+  items={[
+    { icon: "copy", label: "Copy", onClick: () => copy(value) },
+    { icon: "trash", label: "Delete", onClick: () => remove(id) },
+  ]}
+>
+  <div>Right-click me</div>
+</ContextMenu>
+```
+
+### Disabled
+
+```tsx
+<ContextMenu items={items} disabled>
+  <div>Right-click does nothing here</div>
+</ContextMenu>
+```
+
+## See also
+
+- [Tooltip](Tooltip) — supports a `'contextmenu'` trigger for simpler hint-on-right-click
+- [Dialog](Dialog) — for blocking confirmations triggered from menu actions

--- a/wiki/Contributing.md
+++ b/wiki/Contributing.md
@@ -1,0 +1,119 @@
+# Contributing
+
+Thanks for contributing to **vega-react-components**. This page covers the day-to-day workflow. For details, see:
+
+- [Pull Requests](Pull-Requests) — PR template, video requirement, reviews, merge strategy
+- [CI / CD](CI-CD) — the workflows that run on every PR
+- [Release Process](Release-Process) — how versions are published to npm
+- [Architecture](Architecture) — design tokens, conventions, folder structure
+
+## Workflow at a glance
+
+```
+1. Pick or open an issue
+2. Create a branch:  <issue-number>-kebab-case-summary
+3. Code + commit (conventional commits)
+4. Open a PR (template, screenshots/video for UI)
+5. CI must pass (knip → lint → tsc → test → build-storybook)
+6. Get 2 approvals
+7. Squash + merge into main
+8. Thomas publishes to npm manually when appropriate
+```
+
+## 1. Issues
+
+Every change starts with a GitHub [issue](https://github.com/vega-organisation/vegaReact/issues). If one doesn't exist for the work you want to do, **open it first** — the PR validation workflow requires every PR to link an issue.
+
+## 2. Branches
+
+Naming convention: `<issue-number>-kebab-case-summary`
+
+Examples:
+- `34-checkbox-component`
+- `72-readme-update`
+- `88-create-github-wiki`
+
+Branch from up-to-date `main`:
+
+```bash
+git checkout main
+git pull
+git checkout -b 42-add-radio-component
+```
+
+## 3. Commits
+
+We follow **conventional commits** with these prefixes:
+
+| Prefix | Use for |
+|--------|---------|
+| `feat:` | New feature / component |
+| `fix:` | Bug fix |
+| `docs:` | Documentation only |
+| `style:` | Formatting, no code change |
+| `refactor:` | Code change that doesn't add a feature or fix a bug |
+| `perf:` | Performance improvement |
+| `test:` | Adding or fixing tests |
+| `chore:` | Build/tooling/deps |
+| `ci:` | CI configuration |
+
+Optional scope: `feat(ui): add Radio component`. Append the issue number when relevant: `feat(ui): add Radio component #42`.
+
+Examples from the repo log:
+- `feat(ui): add ModelViewer component for GLTF/GLB rendering`
+- `fix(ci): publish workflow auth + clean build type errors`
+- `docs: add components list in COMPONENTS.md #72`
+- `chore: ignore coverage directory`
+
+## 4. Open a Pull Request
+
+See [Pull Requests](Pull-Requests) for the full template and rules. The short version:
+
+- **Title** must start with a conventional-commit prefix (`feat:`, `fix:`, etc.) — enforced by CI
+- **Body** must include `## Description`, `## Testing`, and link the issue with `closes #<n>` / `fixes #<n>` / `resolves #<n>` — enforced by CI
+- **UI changes require a video/GIF** of the result in the PR description
+- Target branch: `main`
+
+## 5. Code review
+
+- **Two approvals are required** before a PR can be merged
+- Address review comments by pushing new commits (don't force-push during review)
+- The reviewers are typically other collaborators on the project
+
+## 6. Merge
+
+We use **Squash and merge** — one clean commit per PR lands on `main`. Edit the squash commit message so it still follows the conventional-commit format.
+
+## 7. Release
+
+The npm package is **not** published automatically. Thomas runs the `Publish to npm` workflow manually when a release is ready. See [Release Process](Release-Process).
+
+## Coding conventions
+
+- **TypeScript strict** — no `any` without justification, no unused locals/params, use `import type` for type-only imports
+- **CSS** — BEM (`.mycomponent`, `.mycomponent--variant`, `.mycomponent__element`), one file per component, design tokens only (no hardcoded colors/spacing) — see [Architecture](Architecture)
+- **Icons** — `lucide-react` only, no custom SVGs
+- **Accessibility** — `useId()` for label/input association, `:focus-visible` for keyboard focus
+- **Stories** — cover all variants, sizes, disabled, full-width
+
+## Adding a new component
+
+Every component lives in `src/components/<ComponentName>/` and must include the **5-file structure**:
+
+```
+src/components/MyComponent/
+├── MyComponent.tsx         # Implementation
+├── MyComponent.types.ts    # Props interface
+├── MyComponent.css         # Scoped styles (BEM)
+├── MyComponent.stories.tsx # Storybook stories
+└── index.ts                # Barrel export
+```
+
+Then register it in `src/index.ts`:
+
+```ts
+export { MyComponent } from "./components/MyComponent";
+export type { MyComponentProps } from "./components/MyComponent/MyComponent.types";
+```
+
+Add a `MyComponent.test.tsx` covering the main behaviors.

--- a/wiki/Dialog.md
+++ b/wiki/Dialog.md
@@ -1,0 +1,85 @@
+# Dialog
+
+Modal window with focus trap, keyboard handling (ESC to close), and accessible markup. Composes with `Dialog.Header`, `Dialog.Body`, `Dialog.Footer`.
+
+## Import
+
+```tsx
+import { Dialog } from "vega-react-components";
+```
+
+## `Dialog` props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `open` | `boolean` | — | **Required.** Whether the dialog is visible. |
+| `onClose` | `() => void` | — | **Required.** Called when the dialog requests to close. |
+| `size` | `'sm' \| 'md' \| 'lg' \| 'fullscreen'` | `'md'` | Dialog size. |
+| `closeOnBackdrop` | `boolean` | `true` | Close when clicking the backdrop. |
+| `children` | `ReactNode` | — | Dialog content. |
+| `className` | `string` | — | Extra class on the dialog box. |
+
+## Sub-components
+
+### `Dialog.Header`
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `children` | `ReactNode` | Header content (e.g. a title). |
+| `onClose` | `() => void` | If provided, renders a close (×) button wired to this handler. |
+| `className` | `string` | Extra class. |
+
+### `Dialog.Body` / `Dialog.Footer`
+
+Both accept `children` and `className`.
+
+## Examples
+
+### Basic
+
+```tsx
+const [open, setOpen] = useState(false);
+
+<Button onClick={() => setOpen(true)}>Open dialog</Button>
+
+<Dialog open={open} onClose={() => setOpen(false)}>
+  <Dialog.Header onClose={() => setOpen(false)}>
+    Confirm action
+  </Dialog.Header>
+  <Dialog.Body>
+    Are you sure you want to delete this item? This cannot be undone.
+  </Dialog.Body>
+  <Dialog.Footer>
+    <Button variant="secondary" onClick={() => setOpen(false)}>Cancel</Button>
+    <Button variant="danger" onClick={handleDelete}>Delete</Button>
+  </Dialog.Footer>
+</Dialog>
+```
+
+### Sizes
+
+```tsx
+<Dialog open size="sm">…</Dialog>
+<Dialog open size="md">…</Dialog>
+<Dialog open size="lg">…</Dialog>
+<Dialog open size="fullscreen">…</Dialog>
+```
+
+### Disable backdrop close
+
+```tsx
+<Dialog open={open} onClose={onClose} closeOnBackdrop={false}>
+  {/* Force user to use the buttons in the footer */}
+</Dialog>
+```
+
+## Accessibility
+
+- Focus is trapped inside the dialog while open
+- Pressing **Escape** triggers `onClose`
+- The dialog has appropriate ARIA roles for screen readers
+
+## See also
+
+- [Toast](Toast) — non-blocking notifications
+- [Tooltip](Tooltip) — lightweight contextual info

--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -1,0 +1,49 @@
+# FAQ
+
+## Does the library work with Next.js App Router?
+
+Yes. `src/index.ts` starts with `"use client"`, so importing any component automatically marks the consumer file as a client component. You can also explicitly wrap usage in a `"use client"` boundary.
+
+## Do I need to import CSS manually?
+
+Yes — once, in your app entry:
+
+```tsx
+import "vega-react-components/style.css";
+```
+
+This file is generated at build time and contains all component styles plus the design tokens.
+
+## Is `lucide-react` required?
+
+Yes — it's a peer dependency used by several components for icons. Install it alongside the library:
+
+```bash
+npm install vega-react-components lucide-react
+```
+
+## Is `react-phone-number-input` required?
+
+Only if you use the `PhoneNumberInput` component. It's an **optional** peer dependency.
+
+## Which React versions are supported?
+
+React **18+** and React **19**. `react` and `react-dom` are peer dependencies.
+
+## Why are there both ESM and CJS bundles?
+
+To support both modern bundlers (ESM via `import`) and Node.js / legacy tooling (CJS via `require`). The right one is selected automatically through the `"exports"` field in `package.json`.
+
+## How can I see all components live?
+
+Run Storybook:
+
+```bash
+npm run storybook
+```
+
+Then open <http://localhost:6006>.
+
+## How do I report a bug or request a feature?
+
+Open an issue on [GitHub](https://github.com/vega-organisation/vegaReact/issues). For contributions, see the [Contributing](Contributing) page.

--- a/wiki/FormWrapper.md
+++ b/wiki/FormWrapper.md
@@ -1,0 +1,94 @@
+# FormWrapper
+
+Form container that provides shared submission state (loading, disabled, error) to its children via React context.
+
+## Import
+
+```tsx
+import { FormWrapper, useFormContext } from "vega-react-components";
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `onSubmit` | `(e: FormEvent<HTMLFormElement>) => void` | — | **Required.** Submit handler. |
+| `isSubmitting` | `boolean` | `false` | Marks the form as submitting (exposed via context). |
+| `disabled` | `boolean` | `false` | Disables the form globally. |
+| `error` | `string` | — | Top-level error message displayed inside the form. |
+| `gap` | `'sm' \| 'md' \| 'lg'` | `'md'` | Spacing between children. |
+| `children` | `ReactNode` | — | Form fields, buttons, etc. |
+| ...rest | `FormHTMLAttributes<HTMLFormElement>` (without `onSubmit`) | — | Standard HTML form attributes. |
+
+## `useFormContext()`
+
+Returns `FormContextValue`:
+
+```ts
+interface FormContextValue {
+  isSubmitting: boolean;
+  isDisabled: boolean;
+  error: string | null;
+}
+```
+
+Use it inside any descendant of `FormWrapper` to react to form state.
+
+## Examples
+
+### Basic
+
+```tsx
+function LoginForm() {
+  const [email, setEmail] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string>();
+
+  const onSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setIsSubmitting(true);
+    try {
+      await login(email);
+    } catch (err) {
+      setError("Invalid credentials");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <FormWrapper
+      onSubmit={onSubmit}
+      isSubmitting={isSubmitting}
+      error={error}
+      gap="md"
+    >
+      <InputEmail
+        label="Email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+      />
+      <Button type="submit">Log in</Button>
+    </FormWrapper>
+  );
+}
+```
+
+### Reading context in a child
+
+```tsx
+function SubmitButton() {
+  const { isSubmitting, isDisabled } = useFormContext();
+
+  return (
+    <Button type="submit" disabled={isDisabled || isSubmitting}>
+      {isSubmitting ? "Sending…" : "Submit"}
+    </Button>
+  );
+}
+```
+
+## See also
+
+- [InputText](InputText), [InputEmail](InputEmail), [PhoneNumberInput](PhoneNumberInput), [Checkbox](Checkbox) — form inputs
+- [Button](Button) — submit buttons

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -1,0 +1,50 @@
+# Getting Started
+
+## Installation
+
+```bash
+npm install vega-react-components lucide-react
+```
+
+`react-phone-number-input` is only required if you use the `PhoneNumberInput` component:
+
+```bash
+npm install react-phone-number-input
+```
+
+### Peer dependencies
+
+| Package | Version |
+|---------|---------|
+| `react` | `>=18.0.0` |
+| `react-dom` | `>=18.0.0` |
+| `lucide-react` | `>=0.400.0` |
+| `react-phone-number-input` *(optional)* | `>=3.4.0` |
+
+## Import styles
+
+Import the global stylesheet **once** at your app entry point (e.g. Next.js `app/layout.tsx`):
+
+```tsx
+import "vega-react-components/style.css";
+```
+
+## Use a component
+
+In the Next.js App Router, components must be used in a client boundary:
+
+```tsx
+"use client";
+
+import { Button } from "vega-react-components";
+
+export function Example() {
+  return <Button variant="primary">Click me</Button>;
+}
+```
+
+## Next steps
+
+- Explore the [Components](Components) list
+- Open Storybook for live examples: `npm run storybook`
+- Read the [Architecture](Architecture) page to understand the design tokens

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,33 @@
+# Vega React Components — Wiki
+
+Welcome to the **vega-react-components** wiki — a React component library distributed as an npm package.
+
+## Quick links
+
+- [Getting Started](Getting-Started) — install and use your first component
+- [Components](Components) — full list of components with detailed pages
+- [Contributing](Contributing) — day-to-day workflow
+- [Local Development](Local-Development) — clone, install, daily commands
+- [Pull Requests](Pull-Requests) — PR template, video requirement, reviews
+- [Testing](Testing) — Vitest + testing-library conventions
+- [Storybook](Storybook) — story file structure, controlled inputs pattern
+- [CI / CD](CI-CD) — the workflows that run on every PR
+- [Release Process](Release-Process) — how versions are published to npm
+- [Architecture](Architecture) — folder structure, build, design tokens
+- [FAQ](FAQ) — common questions
+
+## About
+
+- **Stack**: React 19, TypeScript 5.9, Vite 7, Storybook 10
+- **Distribution**: ESM + CJS bundles, TypeScript declarations included
+- **License**: MIT
+- **Repository**: [vega-organisation/vegaReact](https://github.com/vega-organisation/vegaReact)
+- **npm package**: [`vega-react-components`](https://www.npmjs.com/package/vega-react-components)
+
+## Live documentation
+
+Run Storybook locally to browse every component with interactive controls:
+
+```bash
+npm run storybook
+```

--- a/wiki/InputEmail.md
+++ b/wiki/InputEmail.md
@@ -1,0 +1,51 @@
+# InputEmail
+
+Text input with built-in email format validation. Renders an HTML `input[type="email"]`.
+
+## Import
+
+```tsx
+import { InputEmail } from "vega-react-components";
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `label` | `ReactNode` | — | Label rendered above the input. |
+| `helperText` | `ReactNode` | — | Helper/error text rendered below. |
+| `status` | `'default' \| 'error' \| 'success'` | `'default'` | Visual status. |
+| `size` | `'small' \| 'medium' \| 'large'` | `'medium'` | Input size. |
+| `fullWidth` | `boolean` | `false` | Stretch to fill parent width. |
+| ...rest | `InputHTMLAttributes<HTMLInputElement>` (without `type` and `size`) | — | Standard HTML input attributes. |
+
+## Examples
+
+### Basic
+
+```tsx
+<InputEmail label="Email" placeholder="you@example.com" />
+```
+
+### With error
+
+```tsx
+<InputEmail
+  label="Email"
+  status="error"
+  helperText="Invalid email address"
+  value={email}
+  onChange={(e) => setEmail(e.target.value)}
+/>
+```
+
+### Full width
+
+```tsx
+<InputEmail fullWidth label="Work email" />
+```
+
+## See also
+
+- [InputText](InputText) — generic text input
+- [PhoneNumberInput](PhoneNumberInput) — phone-specific input

--- a/wiki/InputText.md
+++ b/wiki/InputText.md
@@ -1,0 +1,59 @@
+# InputText
+
+Basic text input with label, helper text, validation status, and size variants.
+
+## Import
+
+```tsx
+import { InputText } from "vega-react-components";
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `label` | `ReactNode` | — | Label rendered above the input. |
+| `helperText` | `ReactNode` | — | Helper/error text rendered below. |
+| `status` | `'normal' \| 'error' \| 'success'` | `'normal'` | Visual status (border + helper text color). |
+| `variant` | `'outlined' \| 'filled'` | `'outlined'` | Visual style. |
+| `size` | `'small' \| 'medium' \| 'large'` | `'medium'` | Input size. |
+| `fullWidth` | `boolean` | `false` | Stretch to fill parent width. |
+| ...rest | `InputHTMLAttributes<HTMLInputElement>` (without `size`) | — | Standard HTML input attributes. |
+
+## Examples
+
+### Basic
+
+```tsx
+<InputText label="First name" placeholder="John" />
+```
+
+### With validation
+
+```tsx
+<InputText
+  label="Email"
+  status="error"
+  helperText="Please enter a valid email"
+  value={email}
+  onChange={(e) => setEmail(e.target.value)}
+/>
+```
+
+### Variants and sizes
+
+```tsx
+<InputText variant="filled" size="large" label="Search" />
+<InputText variant="outlined" size="small" label="Code" />
+```
+
+### Full width
+
+```tsx
+<InputText fullWidth label="Address" />
+```
+
+## See also
+
+- [InputEmail](InputEmail) — same API with built-in email validation
+- [FormWrapper](FormWrapper) — wrap inputs to share submission state

--- a/wiki/Loader.md
+++ b/wiki/Loader.md
@@ -1,0 +1,60 @@
+# Loader
+
+Loading indicator with three variants: `spinner`, `skeleton`, `progress`. Supports indeterminate and determinate progress, and an optional full-screen overlay.
+
+## Import
+
+```tsx
+import { Loader } from "vega-react-components";
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `variant` | `'spinner' \| 'skeleton' \| 'progress'` | `'spinner'` | Indicator style. |
+| `value` | `number` (0–100) | — | Only for `progress`. Omit for indeterminate. |
+| `overlay` | `boolean` | `false` | Render a full-screen backdrop that blocks interaction. |
+| `label` | `string` | — | Visually hidden accessibility label. |
+| `width` | `string` | — | CSS width, **skeleton only** (e.g. `"200px"`, `"100%"`). |
+| `height` | `string` | — | CSS height, **skeleton only** (e.g. `"1rem"`, `"80px"`). |
+| `className` | `string` | — | Extra class on the root element. |
+
+## Examples
+
+### Spinner
+
+```tsx
+<Loader />
+<Loader variant="spinner" label="Loading users" />
+```
+
+### Spinner with overlay
+
+```tsx
+{isLoading && <Loader overlay label="Saving…" />}
+```
+
+### Skeleton
+
+```tsx
+<Loader variant="skeleton" width="100%" height="1rem" />
+<Loader variant="skeleton" width="240px" height="120px" />
+```
+
+### Progress (determinate)
+
+```tsx
+<Loader variant="progress" value={uploadedPercent} />
+```
+
+### Progress (indeterminate)
+
+```tsx
+<Loader variant="progress" />
+```
+
+## See also
+
+- [Toast](Toast) — auto-dismissing notifications
+- [ModelViewer](ModelViewer) — uses `Loader` as the default loading fallback

--- a/wiki/Local-Development.md
+++ b/wiki/Local-Development.md
@@ -1,0 +1,129 @@
+# Local Development
+
+Setup for **contributors** who clone the repo. (For **consumers** who just want to install the package, see [Getting Started](Getting-Started).)
+
+## Prerequisites
+
+- **Node.js 24** (matches CI — `nvm install 24 && nvm use 24` if you use nvm)
+- **npm** (comes with Node)
+- Git
+- A code editor with TypeScript support (VS Code recommended)
+
+## Clone and install
+
+```bash
+git clone https://github.com/vega-organisation/vegaReact.git
+cd vegaReact
+npm install
+```
+
+> If you hit peer-dep errors, use `npm install --legacy-peer-deps` (this is what CI uses for some workflows).
+
+## Daily commands
+
+| Command | What it does |
+|---------|--------------|
+| `npm run storybook` | Storybook dev server on http://localhost:6006 — your main workbench |
+| `npm run test:watch` | Vitest in watch mode |
+| `npm test` | Vitest, run once (what CI runs) |
+| `npm run lint` | ESLint |
+| `npm run knip` | Detect unused files / exports / types |
+| `npm run build` | TypeScript check + Vite library build into `dist/` |
+| `npm run build-storybook` | Static Storybook build |
+
+## Editor setup (VS Code)
+
+Recommended extensions:
+
+- **ESLint** (`dbaeumer.vscode-eslint`) — inline lint feedback
+- **Prettier** (optional — the repo doesn't enforce Prettier, but it doesn't hurt)
+- **vscode-styled-components** or similar if you want CSS-in-JS highlights (we use plain CSS files though)
+- **Vitest** (`vitest.explorer`) — run tests from the editor
+
+## Project layout (the parts you'll touch)
+
+```
+src/
+├── assets/styles/         # Global CSS (tokens, typography)
+├── components/            # One folder per component (5-file convention)
+│   └── MyComponent/
+│       ├── MyComponent.tsx
+│       ├── MyComponent.types.ts
+│       ├── MyComponent.css
+│       ├── MyComponent.stories.tsx
+│       ├── MyComponent.test.tsx
+│       └── index.ts
+└── index.ts               # Public exports — add your new component here
+
+.storybook/                # Storybook config
+.github/workflows/         # CI pipelines
+wiki/                      # Wiki source (this folder)
+```
+
+See [Architecture](Architecture) for the full breakdown.
+
+## Adding a component end-to-end
+
+```bash
+git checkout main && git pull
+git checkout -b 42-add-radio-component
+
+# 1. Create the 5-file structure
+mkdir src/components/Radio
+# Create Radio.tsx, Radio.types.ts, Radio.css, Radio.stories.tsx, Radio.test.tsx, index.ts
+
+# 2. Register in src/index.ts:
+# export { Radio } from "./components/Radio";
+# export type { RadioProps } from "./components/Radio/Radio.types";
+
+# 3. Verify locally
+npm run test:watch        # Build it test-first or test-after, your call
+npm run storybook         # Visually verify all variants/sizes/states
+```
+
+See [Contributing](Contributing) for the full workflow and the 5-file convention.
+
+## Pre-PR checklist
+
+Run the same chain CI runs **before pushing** so you don't burn a CI cycle on a typo:
+
+```bash
+npm run knip
+npm run lint
+npx tsc --noEmit
+npm test
+npm run build-storybook
+```
+
+One-liner:
+
+```bash
+npm run knip && npm run lint && npx tsc --noEmit && npm test && npm run build-storybook
+```
+
+If anything fails, fix it locally — don't push a known-broken PR.
+
+## Common gotchas
+
+- **`"use client"` directive at the top of `src/index.ts`** — required for Next.js / RSC. Don't remove it.
+- **`verbatimModuleSyntax: true`** — use `import type { Foo }` for types-only imports, otherwise build fails.
+- **`noUnusedLocals` / `noUnusedParameters`** — even an unused import will fail the build. Clean as you go.
+- **CSS tokens only** — don't hardcode colors / spacing / font sizes. Reference variables from `src/assets/styles/tokens.css` (see [Architecture](Architecture)).
+- **`lucide-react` for icons** — no custom SVGs.
+
+## Troubleshooting
+
+| Symptom | Likely cause / fix |
+|---------|--------------------|
+| `npm install` fails on peer deps | Use `npm install --legacy-peer-deps` |
+| Storybook white-screens after dep update | Delete `node_modules/.cache` and restart |
+| TS error on `import type` rule | You used `import { Foo }` for a type — switch to `import type { Foo }` |
+| Knip complains about unused export | Either use it in `src/index.ts` or remove it |
+| Tests pass locally but fail in CI | Check Node version (CI is Node 24) and that `package-lock.json` is committed |
+
+## See also
+
+- [Contributing](Contributing) — branching, commits, workflow
+- [Testing](Testing) — how to write tests
+- [Storybook](Storybook) — how to write stories
+- [Pull Requests](Pull-Requests) — opening a PR after you're done

--- a/wiki/ModelViewer.md
+++ b/wiki/ModelViewer.md
@@ -1,0 +1,129 @@
+# ModelViewer
+
+Interactive 3D model viewer for `.gltf` / `.glb` files. Built on [@react-three/fiber](https://github.com/pmndrs/react-three-fiber) and [@react-three/drei](https://github.com/pmndrs/drei).
+
+## Import
+
+```tsx
+import { ModelViewer } from "vega-react-components";
+```
+
+## Props
+
+### Model
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `src` | `string` | — | **Required.** URL of the `.gltf` or `.glb` model. |
+| `scale` | `number \| [number, number, number]` | `1` | Uniform or per-axis scale. |
+| `rotation` | `[number, number, number]` | `[0, 0, 0]` | Rotation in **degrees** `[x, y, z]`. |
+| `position` | `[number, number, number]` | `[0, 0, 0]` | Position offset. |
+
+### Canvas
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `width` | `number \| string` | `'100%'` | Canvas width. Number → px, string → any CSS unit. |
+| `height` | `number \| string` | `400` | Canvas height. |
+| `className` | `string` | — | Extra class on the canvas wrapper. |
+| `style` | `CSSProperties` | — | Inline styles on the canvas wrapper. |
+
+### Camera
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `cameraPosition` | `[number, number, number]` | — | Manual camera position. Disables `autoFrame` when set. |
+| `cameraFov` | `number` (degrees) | `50` | Camera field of view. |
+| `autoFrame` | `boolean` | `true` | Auto-fit the camera to the model's bounding box on load. |
+
+### Controls
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `orbit` | `boolean` | `true` | Enable click-drag rotation. |
+| `zoom` | `boolean` | `true` | Enable mouse-wheel zoom. |
+| `pan` | `boolean` | `false` | Enable right-click drag panning. |
+| `autoRotate` | `boolean` | `false` | Continuously rotate the camera. |
+| `autoRotateSpeed` | `number` | `1` | Auto-rotation speed (drei units). |
+| `mouseParallax` | `boolean` | `false` | Subtle parallax: model tilts toward the cursor. |
+| `mouseParallaxIntensity` | `number` (0–1) | `0.1` | Parallax intensity. |
+
+### Lighting / background
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `environment` | `ModelViewerEnvironment` | `'studio'` | HDR preset for PBR lighting. |
+| `background` | `string` | — | Solid background color. Default is transparent. |
+
+`ModelViewerEnvironment`: `'studio' \| 'city' \| 'sunset' \| 'warehouse' \| 'forest' \| 'apartment' \| 'park' \| 'lobby' \| 'night' \| 'dawn'`.
+
+### Fallbacks / events
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `loadingFallback` | `ReactNode` | `<Loader />` | Shown while the model loads. |
+| `errorFallback` | `ReactNode` | simple text | Shown when loading fails. |
+| `onLoad` | `() => void` | — | Fires once the model finishes loading. |
+| `onError` | `(error: Error) => void` | — | Fires on load/parse error. |
+| `onClick` | `() => void` | — | Fires when the user clicks on the model. |
+
+## Examples
+
+### Basic
+
+```tsx
+<ModelViewer src="/models/duck.glb" />
+```
+
+### Custom size and rotation
+
+```tsx
+<ModelViewer
+  src="/models/chair.glb"
+  width={600}
+  height={500}
+  rotation={[0, 45, 0]}
+  scale={1.5}
+/>
+```
+
+### Auto-rotation with environment
+
+```tsx
+<ModelViewer
+  src="/models/sneaker.glb"
+  environment="sunset"
+  autoRotate
+  autoRotateSpeed={0.8}
+  background="#f5f5f5"
+/>
+```
+
+### Disable interactions
+
+```tsx
+<ModelViewer
+  src="/models/logo.glb"
+  orbit={false}
+  zoom={false}
+  mouseParallax
+  mouseParallaxIntensity={0.15}
+/>
+```
+
+### Custom fallback
+
+```tsx
+<ModelViewer
+  src="/models/heavy.glb"
+  loadingFallback={<div>Loading model…</div>}
+  errorFallback={<div>Could not load the model.</div>}
+  onLoad={() => console.log("ready")}
+  onError={(err) => console.error(err)}
+/>
+```
+
+## See also
+
+- [Loader](Loader) — default loading fallback
+- [@react-three/drei docs](https://github.com/pmndrs/drei) for environment presets

--- a/wiki/Navbar.md
+++ b/wiki/Navbar.md
@@ -1,0 +1,99 @@
+# Navbar
+
+Top navigation bar with logo, nav items, optional user menu, and responsive hamburger behavior.
+
+> ⚠️ **Note**: `Navbar` is currently not re-exported from `src/index.ts` (public API). It lives in `src/components/Navbar/` but consumers cannot import it from `vega-react-components` yet. This page documents the component's intended API for upcoming releases.
+
+## Import (when exported)
+
+```tsx
+import { Navbar } from "vega-react-components";
+```
+
+## `Navbar` props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `logo` | `ReactNode` | — | Logo or brand element shown on the left. |
+| `items` | `NavbarItemProps[]` | `[]` | Navigation items. |
+| `userMenu` | `UserMenuProps` | — | Optional user menu (avatar + dropdown). |
+| `isMenuOpen` | `boolean` | `false` | Controlled state of the mobile menu (when set, the navbar becomes controlled). |
+| `onMenuClick` | `() => void` | — | Fires when the hamburger icon is clicked. If provided, the navbar becomes controlled. |
+| `children` | `ReactNode` | — | Optional custom content (e.g. a search bar). |
+| `className` | `string` | — | Extra class on the root. |
+
+### `NavbarItemProps`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `label` | `string` | **Required.** Item text. |
+| `href` | `string` | If provided, renders as a link. |
+| `isActive` | `boolean` | Marks the item as the current page. |
+| `onClick` | `() => void` | Click handler. |
+| `className` | `string` | Extra class. |
+
+### `UserMenuProps`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `avatar` | `string` | Avatar image URL. |
+| `userName` | `string` | Display name. |
+| `menuItems` | `{ label: string; onClick?: () => void; href?: string }[]` | Dropdown entries. |
+
+## Examples
+
+### Basic
+
+```tsx
+<Navbar
+  logo={<img src="/logo.svg" alt="Vega" />}
+  items={[
+    { label: "Home", href: "/", isActive: true },
+    { label: "Docs", href: "/docs" },
+    { label: "Pricing", href: "/pricing" },
+  ]}
+/>
+```
+
+### With user menu
+
+```tsx
+<Navbar
+  logo={<span>Vega</span>}
+  items={navItems}
+  userMenu={{
+    avatar: "/me.jpg",
+    userName: "Alley",
+    menuItems: [
+      { label: "Profile", href: "/profile" },
+      { label: "Settings", href: "/settings" },
+      { label: "Logout", onClick: handleLogout },
+    ],
+  }}
+/>
+```
+
+### Controlled mobile menu
+
+```tsx
+const [open, setOpen] = useState(false);
+
+<Navbar
+  items={navItems}
+  isMenuOpen={open}
+  onMenuClick={() => setOpen(!open)}
+/>
+```
+
+### With custom content (search bar)
+
+```tsx
+<Navbar logo={logo} items={items}>
+  <SearchBar />
+</Navbar>
+```
+
+## See also
+
+- [Sidebar](Sidebar) — vertical navigation
+- [Components](Components) — full component list

--- a/wiki/PhoneNumberInput.md
+++ b/wiki/PhoneNumberInput.md
@@ -1,0 +1,62 @@
+# PhoneNumberInput
+
+International phone input with country selector and E.164 formatting. Built on [`react-phone-number-input`](https://www.npmjs.com/package/react-phone-number-input) (optional peer dep).
+
+## Import
+
+```tsx
+import { PhoneNumberInput } from "vega-react-components";
+```
+
+> Make sure to install the optional peer dependency:
+> ```bash
+> npm install react-phone-number-input
+> ```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `value` | `string` | — | Phone number in E.164 format (e.g. `"+33612345678"`). |
+| `onChange` | `(value?: string) => void` | — | **Required.** Fired on value change. |
+| `defaultCountry` | `Country` (ISO 3166-1 alpha-2) | — | **Required.** Default country code (e.g. `"FR"`, `"US"`). |
+| `label` | `ReactNode` | — | Label rendered above the input. |
+| `helperText` | `ReactNode` | — | Helper/error text rendered below. |
+| `status` | `'default' \| 'error' \| 'success'` | `'default'` | Visual status. |
+| `size` | `'small' \| 'medium' \| 'large'` | `'medium'` | Input size. |
+| `fullWidth` | `boolean` | `false` | Stretch to fill parent width. |
+| `id` | `string` | auto-generated | Optional id for the input element. |
+| ...rest | `InputHTMLAttributes<HTMLInputElement>` (without `onChange`, `value`, `size`) | — | Standard HTML input attributes. |
+
+## Examples
+
+### Basic
+
+```tsx
+const [phone, setPhone] = useState<string>();
+
+<PhoneNumberInput
+  label="Phone"
+  defaultCountry="FR"
+  value={phone}
+  onChange={setPhone}
+/>
+```
+
+### With validation
+
+```tsx
+<PhoneNumberInput
+  label="Phone"
+  defaultCountry="US"
+  status="error"
+  helperText="Invalid phone number"
+  value={phone}
+  onChange={setPhone}
+/>
+```
+
+## See also
+
+- [InputText](InputText) for generic text inputs
+- Library reference: [react-phone-number-input](https://gitlab.com/catamphetamine/react-phone-number-input)

--- a/wiki/Pull-Requests.md
+++ b/wiki/Pull-Requests.md
@@ -1,0 +1,104 @@
+# Pull Requests
+
+Every change to `main` goes through a Pull Request. This page documents the exact conventions our [PR validation workflow](CI-CD#pr-validation) enforces, plus the team-level rules (video, reviews, merge strategy) that aren't in CI but are required.
+
+## Title
+
+The PR title **must start with a conventional-commit prefix** (enforced by CI):
+
+| Prefix | Use for |
+|--------|---------|
+| `feat:` | New feature / component |
+| `fix:` | Bug fix |
+| `docs:` | Documentation only |
+| `style:` | Formatting, no code change |
+| `refactor:` | Code change that doesn't add a feature or fix a bug |
+| `perf:` | Performance improvement |
+| `test:` | Adding or fixing tests |
+| `chore:` | Build/tooling/deps |
+| `ci:` | CI configuration |
+
+Optional scope: `feat(ui): add Radio component`. Keep titles under ~70 chars; put detail in the description.
+
+## Body — required sections
+
+The PR body **must include** (enforced by CI):
+
+1. A linked issue: `closes #<n>`, `fixes #<n>`, or `resolves #<n>`
+2. A `## Description` section
+3. A `## Testing` section
+
+## Recommended template
+
+```markdown
+closes #<issue-number>
+
+## Description
+
+<What this PR changes and why. 1–3 paragraphs or bullets.>
+
+<For UI changes: drag-and-drop a video/GIF here showing the result.>
+
+## Testing
+
+- [ ] `npm run build`
+- [ ] `npm test`
+- [ ] `npm run lint`
+- [ ] Manual check in Storybook
+
+## Notes (optional)
+
+<Anything reviewers should know: trade-offs, follow-ups, out-of-scope items.>
+```
+
+## Video / screenshots (team rule)
+
+**Any PR that changes the UI must include a video or GIF of the result.** Drag-and-drop it directly into the PR description on GitHub — the platform hosts it for you.
+
+What counts as a UI change:
+- New component, new variant, new size
+- Visual change to an existing component (colors, spacing, layout, animation)
+- Storybook story changes that affect the rendered output
+
+A static screenshot is acceptable for trivial visual changes (e.g. a copy update), but a short screen recording is strongly preferred for interactive behavior (hover, focus, animations, modals, etc.).
+
+## Reviews
+
+- **Two approvals are required** before merging
+- Address review comments with **additional commits** (don't force-push during review — it makes the review history unreadable)
+- If a reviewer is unavailable, ping another collaborator rather than waiting indefinitely
+
+## Merge strategy
+
+We use **Squash and merge**. A single commit lands on `main` for each PR.
+
+When you squash, **edit the squash commit message** so it still follows conventional commits:
+
+```
+feat(ui): add Radio component #42
+
+- Adds Radio + RadioGroup components
+- Includes Storybook stories and unit tests
+```
+
+The default GitHub-generated squash message (concatenating all commit titles) is usually noisy — clean it up before clicking "Confirm squash and merge."
+
+## After merge
+
+- Delete the branch (GitHub offers a button after merge)
+- The PR doesn't trigger an npm release — see [Release Process](Release-Process)
+
+## CI checks summary
+
+A PR cannot be merged until all of the following pass:
+
+| Check | What it verifies |
+|-------|------------------|
+| PR Validation | Title prefix, linked issue, Description and Testing sections |
+| Build → Knip | No unused exports/files |
+| Build → Lint | ESLint clean |
+| Build → Type-check | `tsc --noEmit` clean |
+| Build → Test | All Vitest tests pass |
+| Build → Storybook | Storybook compiles |
+
+See [CI / CD](CI-CD) for workflow details.

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -1,0 +1,78 @@
+# Wiki source
+
+This folder contains the markdown source for the project's [GitHub Wiki](https://github.com/vega-organisation/vegaReact/wiki).
+
+## Pages
+
+### General
+| File | Wiki page |
+|------|-----------|
+| `Home.md` | Home (landing page) |
+| `Getting-Started.md` | Getting Started |
+| `Components.md` | Components index |
+| `Contributing.md` | Contributing guide |
+| `Local-Development.md` | Contributor setup, daily commands, pre-PR checklist |
+| `Pull-Requests.md` | PR conventions (template, video, reviews) |
+| `Testing.md` | Vitest + testing-library conventions |
+| `Storybook.md` | Story file structure, patterns |
+| `CI-CD.md` | GitHub Actions workflows |
+| `Release-Process.md` | npm publish process |
+| `Architecture.md` | Architecture / design tokens |
+| `FAQ.md` | FAQ |
+| `_Sidebar.md` | Navigation sidebar (rendered on every wiki page) |
+
+### Components
+| File | Wiki page |
+|------|-----------|
+| `Button.md` | Button |
+| `Checkbox.md` | Checkbox |
+| `InputText.md` | InputText |
+| `InputEmail.md` | InputEmail |
+| `PhoneNumberInput.md` | PhoneNumberInput |
+| `FormWrapper.md` | FormWrapper |
+| `Loader.md` | Loader |
+| `Toast.md` | Toast |
+| `Card.md` | Card |
+| `Sidebar.md` | Sidebar |
+| `Navbar.md` | Navbar |
+| `Dialog.md` | Dialog |
+| `Tooltip.md` | Tooltip |
+| `ContextMenu.md` | ContextMenu |
+| `ModelViewer.md` | ModelViewer |
+
+## How to publish
+
+The GitHub wiki lives in a **separate repo**: `vegaReact.wiki.git`.
+
+```bash
+# Clone the wiki repo (sibling folder)
+git clone https://github.com/vega-organisation/vegaReact.wiki.git
+
+# Copy the pages from this folder
+cp wiki/*.md ../vegaReact.wiki/
+
+# Publish
+cd ../vegaReact.wiki
+git add .
+git commit -m "Update wiki pages"
+git push
+```
+
+> The wiki must be enabled in the repo settings (Settings → Features → Wikis) and at least one page must be created via the web UI before the wiki repo exists and can be cloned.
+
+## Testing locally
+
+GitHub renders wiki pages with GitHub-Flavored Markdown. To preview:
+
+- Open files directly in VS Code (built-in markdown preview)
+- Or use [`grip`](https://github.com/joeyespo/grip) for an accurate GitHub-style preview:
+  ```bash
+  pip install grip
+  grip wiki/Home.md
+  ```
+
+## Conventions
+
+- Use **PascalCase or kebab-case** filenames — they map directly to the wiki URL
+- Cross-link with `[Page name](Page-File-Name)` (no `.md` extension)
+- Keep `_Sidebar.md` updated when adding new pages

--- a/wiki/Release-Process.md
+++ b/wiki/Release-Process.md
@@ -1,0 +1,61 @@
+# Release Process
+
+The npm package is **not** released automatically when a PR merges to `main`. **Thomas** triggers a release manually when a set of changes is ready to ship.
+
+## Who and when
+
+- **Who**: Thomas (maintainer)
+- **When**: at his discretion, typically after a meaningful batch of changes has accumulated on `main` (one or more new components, a bug-fix wave, etc.)
+- **Frequency**: irregular — not a fixed cadence
+
+If you've merged a change you'd like released, ping Thomas in the team channel rather than waiting silently.
+
+## Steps (for the releaser)
+
+### 1. Bump the version
+
+From `main`, on a fresh branch:
+
+```bash
+git checkout main
+git pull
+git checkout -b chore/release-1.x.y
+```
+
+Update `package.json` (`"version": "1.x.y"`). The matching update in `package-lock.json` happens automatically the next time you run `npm install`. Follow [semver](https://semver.org/):
+
+- **Patch** (`1.0.2` → `1.0.3`): bug fixes, no API change
+- **Minor** (`1.0.x` → `1.1.0`): new feature/component, backwards-compatible
+- **Major** (`1.x.y` → `2.0.0`): breaking change
+
+Open a PR with title `chore: release 1.x.y`, get the two approvals, squash-merge.
+
+### 2. Trigger the publish workflow
+
+Once the version bump is on `main`:
+
+1. Go to the [Actions tab](https://github.com/vega-organisation/vegaReact/actions)
+2. Select **Publish to npm**
+3. Click **Run workflow** → choose `main` → **Run workflow**
+
+The workflow builds and runs `npm publish --provenance --access public`. Provenance ties the published artifact to the exact GitHub Actions run, so consumers can verify origin.
+
+### 3. Verify
+
+- The new version appears on [npm](https://www.npmjs.com/package/vega-react-components)
+- `npm install vega-react-components@latest` in a consumer project resolves to the new version
+
+### 4. Announce
+
+Drop a note in the team channel: version, headline changes, link to the [GitHub release](https://github.com/vega-organisation/vegaReact/releases) (optional — we don't always cut a GitHub release).
+
+## Troubleshooting
+
+- **`404 Not Found` during publish** — the `NODE_AUTH_TOKEN` secret is missing or the workflow has a step that runs `npm publish` without the env variable. See PR #83 for the historical fix.
+- **`403 Forbidden`** — the npm account doesn't own `vega-react-components`, or the version was already published. Check `npm view vega-react-components versions`.
+- **Provenance error** — make sure the workflow has `permissions: id-token: write` (it does, but check if you've copied the workflow elsewhere).
+
+## See also
+
+- [CI / CD](CI-CD#publish-to-npm) — workflow file details
+- [Contributing](Contributing) — day-to-day workflow

--- a/wiki/Sidebar.md
+++ b/wiki/Sidebar.md
@@ -1,0 +1,107 @@
+# Sidebar
+
+Vertical navigation panel with header / body / footer composition. Supports collapsed/expanded state on desktop and an overlay drawer on mobile.
+
+## Import
+
+```tsx
+import { Sidebar, useSidebarContext } from "vega-react-components";
+```
+
+## `Sidebar` props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `children` | `ReactNode` | — | Sidebar content (use sub-components). |
+| `defaultExpanded` | `boolean` | `true` | Uncontrolled initial expanded state. |
+| `expanded` | `boolean` | — | Controlled expanded state. |
+| `onExpandedChange` | `(isExpanded: boolean) => void` | — | Called when expanded state changes. |
+| `isOpenMobile` | `boolean` | — | Mobile: whether the overlay drawer is open. |
+| `onCloseMobile` | `() => void` | — | Mobile: callback to close the drawer. |
+| `onOpenMobile` | `() => void` | — | Mobile: callback to open the drawer. |
+| `showMobileTrigger` | `boolean` | `false` | Mobile: show a floating hamburger button. |
+| `className` | `string` | — | Extra class on the root. |
+
+## Sub-components
+
+| Sub-component | Purpose |
+|---------------|---------|
+| `Sidebar.Header` | Top area (logo, app name). |
+| `Sidebar.Body` | Main scrollable area (typically holds `Sidebar.Item`). |
+| `Sidebar.Footer` | Bottom area (user info, settings). |
+| `Sidebar.Item` | A navigation link. Supports `icon`, `href`, `active`, `onClick`, and nested `Sidebar.SubMenu`. |
+| `Sidebar.SubMenu` | Container for nested items under a parent `Sidebar.Item`. |
+| `Sidebar.Toggle` | Collapse/expand button (desktop). |
+
+### `Sidebar.Item` props
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `label` | `string` | **Required.** Text label. |
+| `icon` | `ReactNode` | Optional icon (typically a `lucide-react` icon). |
+| `href` | `string` | If provided, renders as a link. |
+| `active` | `boolean` | Marks the item as the current page. |
+| `onClick` | `() => void` | Click handler. |
+| `children` | `ReactNode` | Nested sub-items (wrap in `Sidebar.SubMenu`). |
+| `className` | `string` | Extra class. |
+
+## `useSidebarContext()`
+
+Returns sidebar state for descendants:
+
+```ts
+interface SidebarContextValue {
+  isExpanded: boolean;
+  // ... see Sidebar source for full shape
+}
+```
+
+## Examples
+
+### Basic
+
+```tsx
+import { Home, Settings, User } from "lucide-react";
+import { Sidebar } from "vega-react-components";
+
+<Sidebar>
+  <Sidebar.Header>My App</Sidebar.Header>
+
+  <Sidebar.Body>
+    <Sidebar.Item label="Dashboard" icon={<Home />} href="/" active />
+    <Sidebar.Item label="Profile" icon={<User />} href="/profile" />
+    <Sidebar.Item label="Settings" icon={<Settings />}>
+      <Sidebar.SubMenu>
+        <Sidebar.Item label="Account" href="/settings/account" />
+        <Sidebar.Item label="Billing" href="/settings/billing" />
+      </Sidebar.SubMenu>
+    </Sidebar.Item>
+  </Sidebar.Body>
+
+  <Sidebar.Footer>
+    <Sidebar.Toggle />
+  </Sidebar.Footer>
+</Sidebar>
+```
+
+### Controlled + mobile
+
+```tsx
+const [expanded, setExpanded] = useState(true);
+const [mobileOpen, setMobileOpen] = useState(false);
+
+<Sidebar
+  expanded={expanded}
+  onExpandedChange={setExpanded}
+  isOpenMobile={mobileOpen}
+  onOpenMobile={() => setMobileOpen(true)}
+  onCloseMobile={() => setMobileOpen(false)}
+  showMobileTrigger
+>
+  {/* ... */}
+</Sidebar>
+```
+
+## See also
+
+- [Components](Components) — full component list

--- a/wiki/Storybook.md
+++ b/wiki/Storybook.md
@@ -1,0 +1,143 @@
+# Storybook
+
+Storybook is our live documentation and visual playground. Every component must have a `<Component>.stories.tsx` file alongside it.
+
+We use **Storybook 10** with the **Vite** builder.
+
+## Running Storybook
+
+```bash
+npm run storybook         # Dev server on http://localhost:6006
+npm run build-storybook   # Static build (run by CI as the final check)
+```
+
+## File location
+
+Stories live next to the component:
+
+```
+src/components/Button/
+├── Button.tsx
+├── Button.stories.tsx   ← here
+└── ...
+```
+
+## Story file structure
+
+### Imports
+
+```tsx
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+import { MyComponent } from "./MyComponent";
+```
+
+> Use `@storybook/react-vite` for the type imports (not `@storybook/react`) and `storybook/test` for `fn` (the spy used in `args`).
+
+### Meta
+
+```tsx
+const meta = {
+  title: "Components/MyComponent",     // Folder path in the sidebar
+  component: MyComponent,
+  parameters: { layout: "centered" },  // or "fullscreen", "padded"
+  tags: ["autodocs"],                  // Generates the auto Docs page
+  argTypes: {
+    variant: {
+      control: "select",
+      options: ["primary", "secondary"],
+      description: "Visual style",
+    },
+    fullWidth: {
+      control: "boolean",
+      description: "Stretch to fill width",
+    },
+  },
+  args: { onClick: fn() },             // Default spy for all stories
+} satisfies Meta<typeof MyComponent>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+```
+
+### Stories
+
+```tsx
+export const Default: Story = {
+  args: { children: "Click me", variant: "primary" },
+};
+
+export const Disabled: Story = {
+  args: { ...Default.args, disabled: true },
+};
+```
+
+## Required coverage
+
+For every component, ship stories for:
+
+- All `variant`s
+- All `size`s
+- Disabled state
+- Full-width (if applicable)
+- Status states (error / success), if the component has them
+- Any composition (sub-components used together — e.g. `Card.Media` + `Card.Body`)
+
+## Controlled components — the `RenderWithState` pattern
+
+For inputs that need a controlled `value`/`onChange` (so the user can actually interact with them in Storybook), wrap with a small local component:
+
+```tsx
+const RenderWithState = (args: PhoneNumberInputProps) => {
+  const [value, setValue] = useState(args.value);
+
+  return (
+    <PhoneNumberInput
+      {...args}
+      value={value}
+      onChange={(newVal) => {
+        setValue(newVal);
+        args.onChange?.(newVal);  // Still call the spy from `args` for Storybook's Actions panel
+      }}
+    />
+  );
+};
+
+export const Default: Story = {
+  render: (args) => <RenderWithState {...args} />,
+  args: {
+    label: "Phone",
+    defaultCountry: "FR",
+  },
+};
+```
+
+See `PhoneNumberInput.stories.tsx` for a complete example.
+
+## Preview config
+
+Global styles and design tokens load in `.storybook/preview.ts`:
+
+```ts
+import '../src/assets/styles/tokens.css';
+import '../src/assets/styles/typography.css';
+```
+
+This means stories render with the same CSS tokens as the published library — no extra setup per story.
+
+## Autodocs
+
+`tags: ["autodocs"]` on the meta generates a Docs page automatically from your `argTypes` and JSDoc comments on the `Props` interface. Keep those comments accurate — they show up in the docs panel.
+
+## Tips
+
+- **Spy with `fn()` from `storybook/test`** for default handlers in `args`. Calls show up in the Actions panel.
+- **Don't import `@storybook/test`** unless the installed `@storybook` package matches that version (note in `AGENTS.md`). Stick to `storybook/test` for now.
+- **`layout: 'centered'`** is the default choice for small components. Use `'fullscreen'` for layout-level components (Sidebar, Navbar, Dialog).
+- **Use `argTypes.control`** to give nicer controls in the Storybook UI (`select`, `boolean`, `text`, `color`, etc.).
+
+## See also
+
+- [Testing](Testing) — unit tests
+- [Contributing](Contributing) — required stories per component
+- [Architecture](Architecture) — design tokens loaded by `preview.ts`

--- a/wiki/Testing.md
+++ b/wiki/Testing.md
@@ -1,0 +1,167 @@
+# Testing
+
+The project uses **Vitest** + **@testing-library/react** in a **happy-dom** environment. Every component should ship with a `*.test.tsx` covering its main behaviors.
+
+## Setup
+
+Config lives in `vitest.config.ts`:
+
+```ts
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    globals: true,                                    // describe/it/expect available globally
+    environment: 'happy-dom',                         // fast, lightweight DOM
+    setupFiles: '@testing-library/jest-dom/vitest',   // adds toBeInTheDocument, toHaveClass, etc.
+    css: true,                                        // include component CSS in tests
+  },
+});
+```
+
+## Running tests
+
+```bash
+npm test            # Run once (used by CI)
+npm run test:watch  # Watch mode for local development
+```
+
+## File location & naming
+
+Tests live **next to** the component, named `<Component>.test.tsx`:
+
+```
+src/components/Button/
+├── Button.tsx
+├── Button.test.tsx   ← here
+└── ...
+```
+
+## What to test
+
+Cover the contract a consumer relies on. For a typical component:
+
+- Renders children / content
+- Applies expected class for each `variant`, `size`, `status`
+- Applies `fullWidth`, `disabled`, and other boolean modifiers
+- Forwards `className` (custom class merging)
+- Fires user handlers (`onClick`, `onChange`, etc.)
+- Respects `disabled` (handler not called)
+- ARIA attributes when relevant (`aria-invalid`, `aria-describedby`)
+
+For complex behavior (Dialog, Tooltip), also cover:
+- Focus management (focus trap, restoration)
+- Keyboard interactions (Escape, Tab, Shift+Tab)
+- Body scroll lock / unlock
+- Backdrop / outside click
+
+## Pattern — basic component test
+
+```tsx
+// Button.test.tsx
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import { Button } from './Button';
+
+describe('Button', () => {
+  it('renders children', () => {
+    render(<Button>Click me</Button>);
+    expect(screen.getByRole('button', { name: 'Click me' })).toBeInTheDocument();
+  });
+
+  it('applies variant class', () => {
+    render(<Button variant="danger">Delete</Button>);
+    expect(screen.getByRole('button')).toHaveClass('vega-button--danger');
+  });
+
+  it('calls onClick handler', async () => {
+    const user = userEvent.setup();
+    const handleClick = vi.fn();
+    render(<Button onClick={handleClick}>Click</Button>);
+    await user.click(screen.getByRole('button'));
+    expect(handleClick).toHaveBeenCalledOnce();
+  });
+
+  it('does not call onClick when disabled', async () => {
+    const user = userEvent.setup();
+    const handleClick = vi.fn();
+    render(<Button disabled onClick={handleClick}>Click</Button>);
+    await user.click(screen.getByRole('button'));
+    expect(handleClick).not.toHaveBeenCalled();
+  });
+});
+```
+
+## Pattern — userEvent over fireEvent
+
+Use `userEvent.setup()` (async) rather than `fireEvent`. It simulates the full event sequence (`pointerdown` → `pointerup` → `click`) and matches real-world behavior.
+
+```tsx
+const user = userEvent.setup();
+await user.click(element);
+await user.type(input, 'hello');
+await user.keyboard('{Escape}');
+await user.tab();
+```
+
+## Pattern — fake timers (only when needed)
+
+Scope fake timers to the tests that actually need them (animations, delays):
+
+```tsx
+it('restores focus after exit animation', () => {
+  vi.useFakeTimers();
+  // ... open dialog, close dialog
+  vi.advanceTimersByTime(250); // animation duration
+  // assert focus restored
+  vi.useRealTimers();
+});
+```
+
+Most tests should stay on real timers + `userEvent` (which handles async cleanly).
+
+## Pattern — mocking heavy dependencies
+
+For components that pull in expensive runtime deps (e.g. three.js in `ModelViewer`), mock them at the top of the test file:
+
+```tsx
+// ModelViewer.test.tsx
+vi.mock('@react-three/fiber', () => ({
+  Canvas: ({ className }: { className?: string }) => (
+    <div data-testid="r3f-canvas" className={className} />
+  ),
+  useFrame: vi.fn(),
+}));
+
+vi.mock('@react-three/drei', () => ({
+  Bounds: ({ children }) => <>{children}</>,
+  Environment: () => null,
+  OrbitControls: () => null,
+  useGLTF: () => ({ scene: {} }),
+  useProgress: () => ({ active: false, progress: 100, errors: [], item: '', loaded: 0, total: 0 }),
+}));
+```
+
+This lets you verify the DOM wrapper logic without actually running WebGL.
+
+## Pattern — `{ hidden: true }` queries
+
+`@testing-library` ignores elements with `aria-hidden="true"` by default. If a parent is hidden (e.g. Dialog backdrop), descendants are unreachable via standard queries — even when they themselves have `aria-hidden="false"`. Pass `{ hidden: true }`:
+
+```tsx
+const closeButton = screen.getByRole('button', { name: /close/i, hidden: true });
+```
+
+This is a real accessibility quirk (`aria-hidden` is not "un-hidable" on descendants), but in tests it's the pragmatic escape hatch. See `Dialog.test.tsx` for usage.
+
+## What NOT to test
+
+- **Visual positioning** (e.g. tooltip placement coordinates). `happy-dom` returns zeroed `getBoundingClientRect`, so position assertions are meaningless. Use Storybook for visual checks.
+- **Library internals** (e.g. `react-phone-number-input` formatting). Trust the upstream package's own tests.
+- **Implementation details** like internal `useState` values. Test the rendered output and the public callbacks.
+
+## See also
+
+- [Storybook](Storybook) — visual + interactive component documentation
+- [CI / CD](CI-CD) — when tests run
+- [Pull Requests](Pull-Requests) — PR Testing section

--- a/wiki/Toast.md
+++ b/wiki/Toast.md
@@ -1,0 +1,96 @@
+# Toast
+
+Auto-dismissing notification system. Wrap your app in `ToastProvider`, then trigger toasts from anywhere via the `useToast()` hook.
+
+## Import
+
+```tsx
+import { ToastProvider, useToast } from "vega-react-components";
+```
+
+## `ToastProvider` props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `children` | `ReactNode` | — | App content. |
+| `position` | `ToastPosition` | `'top-right'` | Where toasts appear on screen. |
+
+`ToastPosition`: `'top-right' \| 'top-left' \| 'top-center' \| 'bottom-right' \| 'bottom-left' \| 'bottom-center'`.
+
+## `useToast()`
+
+Returns:
+
+```ts
+interface ToastContextValue {
+  add: (toast: Omit<ToastData, 'id'>) => string;  // returns the toast id
+  remove: (id: string) => void;
+}
+```
+
+### `ToastData`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `id` | `string` | auto | Internal id (provided by `add`). |
+| `message` | `ReactNode` | — | Toast body. |
+| `title` | `string` | — | Optional title shown above message. |
+| `variant` | `'success' \| 'error' \| 'warning' \| 'info'` | `'info'` | Visual style. |
+| `duration` | `number` | `4000` | ms before auto-dismiss. `0` disables auto-dismiss. |
+
+## Examples
+
+### Setup
+
+```tsx
+// app/layout.tsx (Next.js) or root component
+import { ToastProvider } from "vega-react-components";
+
+export default function RootLayout({ children }) {
+  return (
+    <ToastProvider position="top-right">
+      {children}
+    </ToastProvider>
+  );
+}
+```
+
+### Triggering toasts
+
+```tsx
+"use client";
+import { useToast } from "vega-react-components";
+
+function SaveButton() {
+  const { add } = useToast();
+
+  const onSave = async () => {
+    try {
+      await save();
+      add({ variant: "success", title: "Saved", message: "Your changes are live." });
+    } catch (e) {
+      add({ variant: "error", message: "Could not save. Please retry." });
+    }
+  };
+
+  return <button onClick={onSave}>Save</button>;
+}
+```
+
+### Persistent toast (no auto-dismiss)
+
+```tsx
+const id = add({
+  variant: "warning",
+  message: "Connection lost. Reconnecting…",
+  duration: 0,
+});
+
+// Dismiss manually later
+remove(id);
+```
+
+## See also
+
+- [Loader](Loader) — for ongoing operations
+- [Dialog](Dialog) — for blocking notifications

--- a/wiki/Tooltip.md
+++ b/wiki/Tooltip.md
@@ -1,0 +1,68 @@
+# Tooltip
+
+Contextual hint displayed on hover, click, or right-click. The tooltip auto-flips to stay inside the viewport.
+
+## Import
+
+```tsx
+import { Tooltip } from "vega-react-components";
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `children` | `ReactElement` | — | **Required.** A **single** React element that triggers the tooltip. |
+| `content` | `ReactNode` | — | **Required.** Tooltip content (text or simple React content). |
+| `placement` | `'top' \| 'bottom' \| 'left' \| 'right'` | `'top'` | Preferred placement (may flip if it doesn't fit). |
+| `trigger` | `'hover' \| 'click' \| 'contextmenu' \| 'both'` | `'hover'` | How the tooltip is triggered. `'both'` means hover + click. |
+| `openDelay` | `number` (ms) | `0` | Delay before showing on hover/focus. |
+| `open` | `boolean` | — | Controlled open state (optional). |
+| `onOpenChange` | `(open: boolean) => void` | — | Fires when open state changes. |
+| `className` | `string` | — | Extra class on the tooltip box. |
+
+## Examples
+
+### Basic
+
+```tsx
+<Tooltip content="Save changes">
+  <Button>Save</Button>
+</Tooltip>
+```
+
+### Placement and delay
+
+```tsx
+<Tooltip content="Right side" placement="right" openDelay={200}>
+  <Button>Hover me</Button>
+</Tooltip>
+```
+
+### Click trigger
+
+```tsx
+<Tooltip content="Copied!" trigger="click">
+  <Button onClick={copyToClipboard}>Copy</Button>
+</Tooltip>
+```
+
+### Controlled
+
+```tsx
+const [open, setOpen] = useState(false);
+
+<Tooltip content="Heads up" open={open} onOpenChange={setOpen}>
+  <Button>Trigger</Button>
+</Tooltip>
+```
+
+## Notes
+
+- `children` **must** be a single React element — the tooltip attaches handlers and ARIA attributes to it.
+- For lightweight feedback, prefer `Tooltip`; for blocking choices, use [Dialog](Dialog).
+
+## See also
+
+- [ContextMenu](ContextMenu) — right-click menu
+- [Dialog](Dialog) — blocking modal

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -1,0 +1,45 @@
+### Vega React Components
+
+- [Home](Home)
+- [Getting Started](Getting-Started)
+- [FAQ](FAQ)
+
+**Working on the project**
+
+- [Contributing](Contributing)
+- [Local Development](Local-Development)
+- [Pull Requests](Pull-Requests)
+- [Testing](Testing)
+- [Storybook](Storybook)
+- [CI / CD](CI-CD)
+- [Release Process](Release-Process)
+- [Architecture](Architecture)
+
+**Components**
+
+- [All components](Components)
+
+*Forms*
+- [Button](Button)
+- [Checkbox](Checkbox)
+- [InputText](InputText)
+- [InputEmail](InputEmail)
+- [PhoneNumberInput](PhoneNumberInput)
+- [FormWrapper](FormWrapper)
+
+*Feedback*
+- [Loader](Loader)
+- [Toast](Toast)
+
+*Layout*
+- [Card](Card)
+- [Sidebar](Sidebar)
+- [Navbar](Navbar)
+
+*Overlay*
+- [Dialog](Dialog)
+- [Tooltip](Tooltip)
+- [ContextMenu](ContextMenu)
+
+*Media*
+- [ModelViewer](ModelViewer)


### PR DESCRIPTION
closes #88

## Description

Adds a `wiki/` folder containing the markdown source for the project's GitHub Wiki. The folder is the single place to author wiki content; publishing to the actual wiki (`vegaReact.wiki.git`) is documented in `wiki/README.md`.

### General pages

- `Home` — landing page with quick links
- `Getting-Started` — install + first usage for consumers
- `Components` — index by category, links to each component page
- `Contributing` — workflow overview (issue → branch → PR → review → merge → release)
- `Local-Development` — contributor setup, daily commands, pre-PR checklist
- `Pull-Requests` — PR title/body conventions, video requirement for UI, 2 approvals, squash & merge
- `Testing` — Vitest + testing-library patterns, mocking heavy deps, what not to test
- `Storybook` — story file structure, `RenderWithState` for controlled inputs, autodocs
- `CI-CD` — breakdown of `pr-validation.yml`, `build.yml`, `publish.yml`
- `Release-Process` — manual publish flow, semver, troubleshooting
- `Architecture` — folder layout, design tokens, CSS/TS conventions
- `FAQ` — common consumer questions
- `_Sidebar` — sidebar nav rendered on every wiki page

### Component reference pages (14)

- Forms: Button, Checkbox, InputText, InputEmail, PhoneNumberInput, FormWrapper
- Feedback: Loader, Toast
- Layout: Card, Sidebar, Navbar
- Overlay: Dialog, Tooltip, ContextMenu
- Media: ModelViewer

> `Navbar` page notes that the component is not yet re-exported from `src/index.ts` (intentional — flagged for a future release).

## Testing

- [x] Local preview via `grip` — all pages render with correct GitHub-flavored markdown
- [x] Internal cross-links use the wiki-style `[Page](Page-File-Name)` (no `.md` extension)
- [x] `_Sidebar.md` and `Home.md` reference every page
- [ ] Visual check after publishing to the actual GitHub wiki
- [ ] Confirm wiki is enabled in repo settings before first publish

## Notes

- This PR only adds the source files. Publishing to the GitHub wiki is a separate step (manual `git push` to `vegaReact.wiki.git`), documented in `wiki/README.md`.
- No source code is touched — only the new `wiki/` folder.