### PR TITLE
 feat: add CodeBlock component with dark/light and edit modes

### DIFF
--- a/COMPONENTS.md
+++ b/COMPONENTS.md
@@ -25,6 +25,7 @@ npm install vega-react-components
 ## Layout
 
 - **Card** — Container with variants and composition for grouping content.
+- **CodeBlock** — Component to display code with language support, line numbers, and copy functionality.
 
 ## Overlay
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,8 @@
         "three": "^0.184.0"
       },
       "devDependencies": {
+        "@emnapi/core": "^1.10.0",
+        "@emnapi/runtime": "^1.10.0",
         "@eslint/js": "^9.36.0",
         "@storybook/addon-onboarding": "^10.2.12",
         "@storybook/react": "^10.4.0",
@@ -340,12 +342,32 @@
       "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
       "license": "Apache-2.0"
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
       "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
-      "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@storybook/addon-onboarding": "^10.2.12",
         "@storybook/react": "^10.4.0",
         "@storybook/react-vite": "^10.2.12",
+        "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -338,29 +339,6 @@
       "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
       "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
       "license": "Apache-2.0"
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
@@ -2625,7 +2603,6 @@
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -2731,8 +2708,7 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2834,6 +2810,7 @@
       "version": "19.2.15",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
       "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
+      "dev": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3570,7 +3547,6 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -3948,7 +3924,8 @@
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
-      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true
     },
     "node_modules/de-indent": {
       "version": "1.0.2",
@@ -4062,8 +4039,7 @@
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/draco3d": {
       "version": "1.5.7",
@@ -5210,7 +5186,6 @@
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -5663,7 +5638,6 @@
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -5678,7 +5652,6 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -5746,6 +5719,7 @@
       "version": "19.2.6",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5784,7 +5758,7 @@
       "version": "19.2.6",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
       "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5796,8 +5770,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/react-phone-number-input": {
       "version": "3.4.16",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
     }
   },
   "devDependencies": {
+    "@emnapi/core": "^1.10.0",
+    "@emnapi/runtime": "^1.10.0",
     "@eslint/js": "^9.36.0",
     "@storybook/addon-onboarding": "^10.2.12",
     "@storybook/react": "^10.4.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@storybook/addon-onboarding": "^10.2.12",
     "@storybook/react": "^10.4.0",
     "@storybook/react-vite": "^10.2.12",
+    "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/src/components/CodeBlock/CodeBlock.css
+++ b/src/components/CodeBlock/CodeBlock.css
@@ -1,0 +1,149 @@
+.vega-code-block {
+  --cb-bg: var(--neutral-900);
+  --cb-header-bg: var(--neutral-800);
+  --cb-header-border: var(--neutral-700);
+  --cb-text: var(--text-inverse);
+  --cb-border: var(--border-default);
+  --cb-line-number-opacity: 0.3;
+  --cb-line-number-border: rgba(255, 255, 255, 0.1);
+  --cb-copy-bg: var(--neutral-700);
+  --cb-copy-hover-bg: var(--neutral-600);
+
+  position: relative;
+  background-color: var(--cb-bg);
+  border-radius: 8px;
+  overflow: hidden;
+  margin: 1rem 0;
+  border: 1px solid var(--cb-border);
+}
+
+.vega-code-block--light {
+  --cb-bg: var(--neutral-0);
+  --cb-header-bg: var(--neutral-100);
+  --cb-header-border: var(--neutral-200);
+  --cb-text: var(--text-main);
+  --cb-line-number-opacity: 0.4;
+  --cb-line-number-border: var(--neutral-200);
+  --cb-copy-bg: var(--neutral-200);
+  --cb-copy-hover-bg: var(--neutral-300);
+}
+
+.vega-code-block__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5rem 1rem;
+  background-color: var(--cb-header-bg);
+  border-bottom: 1px solid var(--cb-header-border);
+  color: var(--cb-text);
+  font-size: var(--font-size-xs);
+  font-family: var(--font-family-base);
+}
+
+.vega-code-block__label {
+  font-weight: var(--font-weight-medium);
+  opacity: 0.8;
+}
+
+.vega-code-block__language {
+  text-transform: uppercase;
+  font-weight: var(--font-weight-bold);
+  opacity: 0.6;
+}
+.vega-code-block__content {
+  margin: 0;
+  padding: 1rem;
+  overflow-x: auto;
+  color: var(--cb-text);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-relaxed);
+  min-height: 4rem;
+}
+
+.vega-code-block__textarea {
+  width: 100%;
+  background: transparent;
+  border: none;
+  color: var(--cb-text);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-relaxed);
+  padding: 1rem;
+  margin: 0;
+  resize: vertical;
+  outline: none;
+  display: block;
+  box-sizing: border-box;
+}
+
+.vega-code-block__button {
+  background-color: var(--cb-copy-bg);
+  border: none;
+  border-radius: 4px;
+  color: var(--cb-text);
+  padding: 0.25rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.2s ease;
+}
+
+.vega-code-block__button:hover {
+  background-color: var(--cb-copy-hover-bg);
+}
+
+.vega-code-block--light .vega-code-block__button {
+  color: var(--text-main);
+}
+
+.vega-code-block__copy {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  z-index: 10;
+}
+
+.vega-code-block--with-header .vega-code-block__copy {
+  position: static;
+  background-color: transparent;
+}
+
+.vega-code-block--with-header .vega-code-block__copy {
+  position: static;
+  background-color: transparent;
+  padding: 2px;
+}
+
+.vega-code-block--with-header .vega-code-block__copy:hover {
+  background-color: var(--cb-copy-bg);
+}
+
+.vega-code-block__content code {
+  display: block;
+  min-width: fit-content;
+}
+
+/* Line numbers styling */
+.vega-code-block__line {
+  display: flex;
+  line-height: var(--line-height-relaxed);
+  min-height: 1.5em;
+}
+
+.vega-code-block__line-number {
+  flex-shrink: 0;
+  width: 3rem;
+  text-align: right;
+  padding-right: 1rem;
+  user-select: none;
+  opacity: var(--cb-line-number-opacity);
+  margin-right: 1rem;
+  border-right: 1px solid var(--cb-line-number-border);
+}
+
+.vega-code-block__line-content {
+  flex-grow: 1;
+  padding-left: 0.5rem;
+}

--- a/src/components/CodeBlock/CodeBlock.stories.tsx
+++ b/src/components/CodeBlock/CodeBlock.stories.tsx
@@ -1,0 +1,103 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { CodeBlock } from './CodeBlock';
+
+const meta = {
+  title: 'Components/CodeBlock',
+  component: CodeBlock,
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    code: { control: 'text' },
+    language: { control: 'text' },
+    label: { control: 'text' },
+    showLineNumbers: { control: 'boolean' },
+    showCopyButton: { control: 'boolean' },
+  },
+} satisfies Meta<typeof CodeBlock>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const sampleCode = `function helloWorld() {
+  console.log("Hello, world!");
+  return true;
+}
+
+const result = helloWorld();
+console.log(result);`;
+
+export const Default: Story = {
+  args: {
+    code: sampleCode,
+  },
+};
+
+export const WithLanguage: Story = {
+  args: {
+    code: sampleCode,
+    language: 'javascript',
+  },
+};
+
+export const WithLabel: Story = {
+  args: {
+    code: sampleCode,
+    language: 'javascript',
+    label: 'hello.js',
+  },
+};
+
+export const WithLineNumbers: Story = {
+  args: {
+    code: sampleCode,
+    language: 'javascript',
+    showLineNumbers: true,
+  },
+};
+
+export const LightMode: Story = {
+  args: {
+    code: sampleCode,
+    variant: 'light',
+  },
+};
+
+export const LightModeWithHeader: Story = {
+  args: {
+    code: sampleCode,
+    variant: 'light',
+    language: 'javascript',
+    label: 'main.js',
+    showLineNumbers: true,
+  },
+};
+
+export const Editable: Story = {
+  args: {
+    code: sampleCode,
+    isEditable: true,
+    language: 'javascript',
+    label: 'editable.js',
+  },
+};
+
+export const EditableLight: Story = {
+  args: {
+    code: sampleCode,
+    isEditable: true,
+    variant: 'light',
+    language: 'javascript',
+    label: 'editable-light.js',
+  },
+};
+
+export const LongCode: Story = {
+  args: {
+    code: Array(20).fill(sampleCode).join('\n\n'),
+    language: 'javascript',
+    showLineNumbers: true,
+    label: 'long-script.js',
+  },
+};

--- a/src/components/CodeBlock/CodeBlock.test.tsx
+++ b/src/components/CodeBlock/CodeBlock.test.tsx
@@ -1,0 +1,112 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { CodeBlock } from './CodeBlock';
+
+// Mock clipboard API
+const mockClipboard = {
+  writeText: vi.fn().mockImplementation(() => Promise.resolve()),
+};
+
+Object.defineProperty(navigator, 'clipboard', {
+  value: mockClipboard,
+  configurable: true,
+});
+
+describe('CodeBlock', () => {
+  const sampleCode = 'console.log("hello");';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders code correctly', () => {
+    render(<CodeBlock code={sampleCode} />);
+    expect(screen.getByText('console.log("hello");')).toBeInTheDocument();
+  });
+
+  it('renders language and label when provided', () => {
+    render(<CodeBlock code={sampleCode} language="js" label="test.js" />);
+    expect(screen.getByText('js')).toBeInTheDocument();
+    expect(screen.getByText('test.js')).toBeInTheDocument();
+  });
+
+  it('shows copy button by default', () => {
+    render(<CodeBlock code={sampleCode} />);
+    expect(screen.getByRole('button', { name: /copy code/i })).toBeInTheDocument();
+  });
+
+  it('hides copy button when showCopyButton is false', () => {
+    render(<CodeBlock code={sampleCode} showCopyButton={false} />);
+    expect(screen.queryByRole('button', { name: /copy code/i })).not.toBeInTheDocument();
+  });
+
+  it('copies code to clipboard when clicking copy button', async () => {
+    render(<CodeBlock code={sampleCode} />);
+    const copyBtn = screen.getByRole('button', { name: /copy code/i });
+    
+    fireEvent.click(copyBtn);
+    
+    expect(mockClipboard.writeText).toHaveBeenCalledWith(sampleCode);
+    
+    // Check if icon changes (using aria-label or title)
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /copied!/i })).toBeInTheDocument();
+    });
+  });
+
+  it('renders line numbers when showLineNumbers is true', () => {
+    const multiLineCode = 'line 1\nline 2';
+    render(<CodeBlock code={multiLineCode} showLineNumbers />);
+    
+    expect(screen.getByText('1')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getByText('line 1')).toBeInTheDocument();
+    expect(screen.getByText('line 2')).toBeInTheDocument();
+  });
+
+  it('applies custom className', () => {
+    render(<CodeBlock code={sampleCode} className="custom-class" />);
+    const container = screen.getByText('console.log("hello");').closest('.vega-code-block');
+    expect(container).toHaveClass('custom-class');
+  });
+
+  it('shows edit button when isEditable is true', () => {
+    render(<CodeBlock code={sampleCode} isEditable />);
+    expect(screen.getByRole('button', { name: /edit code/i })).toBeInTheDocument();
+  });
+
+  it('switches to textarea when clicking edit button', () => {
+    render(<CodeBlock code={sampleCode} isEditable />);
+    const editBtn = screen.getByRole('button', { name: /edit code/i });
+    
+    fireEvent.click(editBtn);
+    
+    const textarea = screen.getByPlaceholderText(/enter code here/i);
+    expect(textarea).toBeInTheDocument();
+    expect(textarea).toHaveValue(sampleCode);
+  });
+
+  it('calls onCodeChange when editing', () => {
+    const handleChange = vi.fn();
+    render(<CodeBlock code={sampleCode} isEditable onCodeChange={handleChange} />);
+    
+    fireEvent.click(screen.getByRole('button', { name: /edit code/i }));
+    const textarea = screen.getByPlaceholderText(/enter code here/i);
+    
+    fireEvent.change(textarea, { target: { value: 'new code' } });
+    
+    expect(handleChange).toHaveBeenCalledWith('new code');
+    expect(textarea).toHaveValue('new code');
+  });
+
+  it('switches back to preview when clicking eye button', () => {
+    render(<CodeBlock code={sampleCode} isEditable />);
+    
+    fireEvent.click(screen.getByRole('button', { name: /edit code/i }));
+    expect(screen.getByPlaceholderText(/enter code here/i)).toBeInTheDocument();
+    
+    fireEvent.click(screen.getByRole('button', { name: /show preview/i }));
+    expect(screen.queryByPlaceholderText(/enter code here/i)).not.toBeInTheDocument();
+    expect(screen.getByText(sampleCode)).toBeInTheDocument();
+  });
+});

--- a/src/components/CodeBlock/CodeBlock.tsx
+++ b/src/components/CodeBlock/CodeBlock.tsx
@@ -1,0 +1,129 @@
+import React, { useState, useEffect } from 'react';
+import { Check, Copy, Pencil, Eye } from 'lucide-react';
+import type { CodeBlockProps } from './CodeBlock.types';
+import './CodeBlock.css';
+
+export const CodeBlock: React.FC<CodeBlockProps> = ({
+  code: initialCode,
+  language,
+  showLineNumbers = false,
+  showCopyButton = true,
+  label,
+  variant = 'dark',
+  isEditable = false,
+  onCodeChange,
+  className = '',
+  ...props
+}) => {
+  const [code, setCode] = useState(initialCode);
+  const [copied, setCopied] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+
+  useEffect(() => {
+    setCode(initialCode);
+  }, [initialCode]);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error('Failed to copy code: ', err);
+    }
+  };
+
+  const handleTextareaChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const newCode = e.target.value;
+    setCode(newCode);
+    onCodeChange?.(newCode);
+  };
+
+  const lines = code.trim().split('\n');
+  const hasHeader = !!(label || language || isEditable || (showCopyButton && (label || language)));
+
+  const containerClasses = [
+    'vega-code-block',
+    `vega-code-block--${variant}`,
+    hasHeader ? 'vega-code-block--with-header' : '',
+    isEditing ? 'vega-code-block--editing' : '',
+    className,
+  ].filter(Boolean).join(' ');
+
+  const copyButton = showCopyButton && (
+    <button
+      type="button"
+      className={`vega-code-block__button vega-code-block__copy ${copied ? 'vega-code-block__copy--success' : ''}`}
+      onClick={handleCopy}
+      aria-label={copied ? 'Copied!' : 'Copy code'}
+      title={copied ? 'Copied!' : 'Copy code'}
+    >
+      {copied ? <Check size={16} /> : <Copy size={16} />}
+    </button>
+  );
+
+  const editToggleButton = isEditable && (
+    <button
+      type="button"
+      className="vega-code-block__button vega-code-block__edit-toggle"
+      onClick={() => setIsEditing(!isEditing)}
+      aria-label={isEditing ? 'Show preview' : 'Edit code'}
+      title={isEditing ? 'Show preview' : 'Edit code'}
+    >
+      {isEditing ? <Eye size={16} /> : <Pencil size={16} />}
+    </button>
+  );
+
+  return (
+    <div className={containerClasses}>
+      {hasHeader && (
+        <div className="vega-code-block__header">
+          <div className="vega-code-block__header-left">
+            {label && <span className="vega-code-block__label">{label}</span>}
+            {label && language && <span style={{ margin: '0 0.5rem', opacity: 0.3 }}>|</span>}
+            {language && <span className="vega-code-block__language">{language}</span>}
+          </div>
+          <div className="vega-code-block__header-right" style={{ display: 'flex', gap: '0.5rem' }}>
+            {editToggleButton}
+            {copyButton}
+          </div>
+        </div>
+      )}
+
+      {!hasHeader && (
+        <div style={{ position: 'absolute', top: '0.5rem', right: '0.5rem', display: 'flex', gap: '0.5rem', zIndex: 10 }}>
+          {editToggleButton}
+          {copyButton}
+        </div>
+      )}
+
+      {isEditing ? (
+        <textarea
+          className="vega-code-block__textarea"
+          value={code}
+          onChange={handleTextareaChange}
+          placeholder="Enter code here..."
+          spellCheck={false}
+          rows={Math.max(lines.length, 3)}
+        />
+      ) : (
+        <pre className="vega-code-block__content" {...props}>
+          <code>
+            {showLineNumbers ? (
+              lines.map((line, index) => (
+                <span key={index} className="vega-code-block__line">
+                  <span className="vega-code-block__line-number">{index + 1}</span>
+                  <span className="vega-code-block__line-content">{line}</span>
+                </span>
+              ))
+            ) : (
+              code.trim()
+            )}
+          </code>
+        </pre>
+      )}
+    </div>
+  );
+};
+
+CodeBlock.displayName = 'CodeBlock';

--- a/src/components/CodeBlock/CodeBlock.types.ts
+++ b/src/components/CodeBlock/CodeBlock.types.ts
@@ -1,0 +1,20 @@
+import type { HTMLAttributes } from 'react';
+
+export interface CodeBlockProps extends HTMLAttributes<HTMLPreElement> {
+  /** The code to display */
+  code: string;
+  /** The programming language of the code */
+  language?: string;
+  /** Whether to show line numbers */
+  showLineNumbers?: boolean;
+  /** Whether to show a copy button */
+  showCopyButton?: boolean;
+  /** Label for the code block (e.g. filename) */
+  label?: string;
+  /** The theme variant of the code block */
+  variant?: 'dark' | 'light';
+  /** Whether the code is editable */
+  isEditable?: boolean;
+  /** Callback when the code is changed (only if isEditable is true) */
+  onCodeChange?: (newCode: string) => void;
+}

--- a/src/components/CodeBlock/index.ts
+++ b/src/components/CodeBlock/index.ts
@@ -1,0 +1,2 @@
+export { CodeBlock } from './CodeBlock';
+export type { CodeBlockProps } from './CodeBlock.types';

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,3 +65,5 @@ export type {
   SidebarToggleProps,
   SidebarContextValue,
 } from "./components/Sidebar";
+export { CodeBlock } from "./components/CodeBlock";
+export type { CodeBlockProps } from "./components/CodeBlock/CodeBlock.types";


### PR DESCRIPTION
   ## Description
   This PR introduces the `CodeBlock` component, which supports syntax highlighting (conceptual), dark/light theme variants, and a toggleable read/edit mode. It follows all project conventions and is fully tested.
  
   Resolves #89
  
   ## Testing
   - Unit tests created in `src/components/CodeBlock/CodeBlock.test.tsx` (11 passing).
   - Manual verification via Storybook with all variants.
   - Ran `npm run lint` and `npm run build`.

<img width="2554" height="982" alt="image" src="https://github.com/user-attachments/assets/d931136e-54fc-4611-a55d-3e1e30313bba" />
<img width="2554" height="982" alt="image" src="https://github.com/user-attachments/assets/7ba19057-0c51-4a13-9982-4364ca416dc0" />
<img width="2559" height="1021" alt="image" src="https://github.com/user-attachments/assets/e8c601ce-fd81-4c05-9042-882dec9580b8" />
<img width="1276" height="1021" alt="image" src="https://github.com/user-attachments/assets/705acdde-4ddc-4abc-80e6-de05adf2d5e1" />
<img width="1276" height="1021" alt="image" src="https://github.com/user-attachments/assets/526be0ac-7bec-47b8-8c4c-999868abc4c2" />
<img width="1276" height="1021" alt="image" src="https://github.com/user-attachments/assets/f5ce5ef3-a005-4d6e-80df-2741d624c563" />
<img width="1276" height="1318" alt="image" src="https://github.com/user-attachments/assets/36d4bd3d-1227-4fdc-8e7d-4c8602cb08e8" />
